### PR TITLE
Fix: [EVER-29] create close issue action관련 오류 수정

### DIFF
--- a/.github/workflows/close-jira-issue.yml
+++ b/.github/workflows/close-jira-issue.yml
@@ -1,8 +1,7 @@
 name: Close Jira issue
 on:
   issues:
-    types:
-      - closed
+    types: [closed]
 
 jobs:
   close-issue:
@@ -10,23 +9,32 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
       - name: Login to Jira
         uses: atlassian/gajira-login@v3
         env:
-          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
-          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          JIRA_BASE_URL:   ${{ secrets.JIRA_BASE_URL }}
+          JIRA_API_TOKEN:  ${{ secrets.JIRA_API_TOKEN }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
 
-      - name: Extract Jira issue key from GitHub issue title
-        id: extract-key
+      - name: Issue Parser
+        uses: stefanbuck/github-issue-praser@v3
+        id: issue-parser
+        with:
+          template-path: .github/ISSUE_TEMPLATE/feature-request-form.yml   # ← 실제 사용 중인 폼 경로
+          issue-body: ${{ github.event.issue.body }}
+
+      - name: Log parsed parentKey
         run: |
-          ISSUE_TITLE="${{ github.event.issue.title }}"
-          JIRA_KEY=$(echo "$ISSUE_TITLE" | grep -oE '[A-Z]+-[0-9]+')
-          echo "JIRA_KEY=$JIRA_KEY" >> $GITHUB_ENV
+          echo "PARENT_KEY='${{ steps.issue-parser.outputs.issueparser_parentKey }}'"
 
       - name: Close Jira issue
-        if: env.JIRA_KEY != ''
+        if: ${{ steps.issue-parser.outputs.issueparser_parentKey != '' }}
         uses: atlassian/gajira-transition@v3
         with:
-          issue: ${{ env.JIRA_KEY }}
-          transitionId: '31'
+          issue: ${{ steps.issue-parser.outputs.issueparser_parentKey }}
+          transitionId: '31

--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -26,6 +26,16 @@ jobs:
         with:
           ref: main
 
+      - name: Select Issue-Form Template
+        id: select-template
+        run: |
+          TITLE="${{ github.event.issue.title }}"
+          if [[ "$TITLE" == "[BUG]"* ]]; then
+            echo "template_path=.github/ISSUE_TEMPLATE/bug-report-form.yml" >> $GITHUB_OUTPUT
+          else
+            echo "template_path=.github/ISSUE_TEMPLATE/feature-request-form.yml" >> $GITHUB_OUTPUT
+          fi
+
       - name: Issue Parser
         uses: stefanbuck/github-issue-praser@v3
         id: issue-parser


### PR DESCRIPTION
### #️⃣연관된 이슈

> close: #7 

### 🔎 작업 내용

- [x] create-issue. yml에서 template-path 연결 오류로 인해 parentKey 전달 잘못됨 -> jira에서 어느 Task에 할 일 만들지 못 찾아서 오류 발생하는 것 수정
- [x] close-issue.yml에서 parentKey를 이슈 제목이 아니라 이슈 contents에서 찾도록 변경

### 📸 스크린샷

### :loudspeaker: 전달사항

- 테스트 완료되면 확인 후 이슈 닫음

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
