### PR TITLE
Fix: [EVER-29] yml files updated

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-form.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report-form.yml
@@ -3,6 +3,23 @@ description: '버그 리포트를 위한 양식입니다. 생성된 이슈는 Ji
 labels: [bug]
 title: '[BUG] 이슈 이름을 작성해주세요'
 body:
+  - type: dropdown
+    id: issuetype
+    attributes:
+      label: '🔖 이슈 유형 (Jira Issue Type)'
+      description: 'Jira 상에서 사용할 이슈 타입을 선택해주세요'
+      options:
+        - label: Task
+          value: Task
+        - label: Sub-task
+          value: Sub-task
+        - label: Story
+          value: Story
+        - label: Epic
+          value: Epic
+    validations:
+      required: true
+
   - type: input
     id: parentKey
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request-form.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request-form.yml
@@ -3,11 +3,28 @@ description: '새로운 기능을 제안하기 위한 양식입니다. 생성된
 labels: [enhancement]
 title: '[FEAT] 이슈 이름을 작성해주세요'
 body:
+  - type: dropdown
+    id: issuetype
+    attributes:
+      label: '🔖 이슈 유형 (Jira Issue Type)'
+      description: 'Jira 상에서 사용할 이슈 타입을 선택해주세요'
+      options:
+        - label: Task
+          value: Task
+        - label: Sub-task
+          value: Sub-task
+        - label: Story
+          value: Story
+        - label: Epic
+          value: Epic
+    validations:
+      required: true
+
   - type: input
     id: parentKey
     attributes:
       label: '🎟️ 상위 작업 (Ticket Number)'
-      description: '연동할 상위 Jira 티켓 키(PRJ-00) 를 입력해주세요'
+      description: '연결할 상위 Jira 티켓 키(PRJ-00) 를 입력해주세요'
       placeholder: 'PRJ-00'
     validations:
       required: true

--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Log Issue Parser
         run: |
+          echo '${{ steps.issue-parser.outputs.issueparser_issuetype }}'
           echo '${{ steps.issue-parser.outputs.issueparser_parentKey }}'
           echo '${{ steps.issue-parser.outputs.__ticket_number }}'
           echo '${{ steps.issue-parser.outputs.jsonString }}'
@@ -65,7 +66,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: EVER
-          issuetype: Task
+          issuetype: ${{ steps.issue-parser.outputs.issueparser_issuetype }}
           summary: '${{ github.event.issue.title }}'
           description: '${{ steps.md2jira.outputs.output-text }}'
           fields: |


### PR DESCRIPTION
### #️⃣연관된 이슈

Epic이 아닌 경우 전부 Sub-Task여야만 Issue를 통해서 자식으로 들어갈 수 있는데, 현재는 Type이 Task로 고정되어 있어 신청 불가능한 현상 발생, sub-Task랑 Task를 고를 수 있도록 변경

> #7 

### 🔎 작업 내용

- [x] template, jira.yml 변경 완료


### 📸 스크린샷

### :loudspeaker: 전달사항


## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
