### PR TITLE
Fix: [EVER-29] same id in two jobs

### DIFF
--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -73,7 +73,7 @@ jobs:
       # 8-a) parentKey가 존재할 경우만 fields 전달
       - name: Create Issue with parent
         if: ${{ steps.issue-parser.outputs.issueparser_parentKey != '' }}
-        id: create
+        id: create-with-parent
         uses: atlassian/gajira-create@v3
         with:
           project: EVER
@@ -88,7 +88,7 @@ jobs:
       # 8-b) parentKey가 비어있을 경우 fields 생략
       - name: Create Issue without parent
         if: ${{ steps.issue-parser.outputs.issueparser_parentKey == '' }}
-        id: create
+        id: create-without-parent
         uses: atlassian/gajira-create@v3
         with:
           project: EVER


### PR DESCRIPTION
### #️⃣연관된 이슈

#7

### 🔎 작업 내용

- [x] parnetKey 파트 same id로 인한 오류 수정

### 📸 스크린샷

### :loudspeaker: 전달사항

- 추가한 라이브러리나 특이 사항

## ✅ Check List

- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
