### PR TITLE
Fix: [EVER-118] ServerSentEvent형식의 응답으로 전부 수정하여 스트리밍 지원

### DIFF
--- a/src/main/java/com/team4ever/backend/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/team4ever/backend/domain/chat/controller/ChatController.java
@@ -11,6 +11,8 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 
+import org.springframework.http.codec.ServerSentEvent;
+
 @RestController
 @RequestMapping("/api/chat")
 @RequiredArgsConstructor
@@ -18,64 +20,23 @@ public class ChatController {
 
 	private final ChatService chatService;
 
-	/**
-	 * 채팅 스트리밍 엔드포인트
-	 *
-	 * 예외사항: 전역 BaseResponse 래퍼를 사용하지 않습니다.
-	 *         기본 응답 형식을 위배하지만,
-	 *         FastAPI에서 내려오는 NDJSON/plain text 청크를
-	 *         Flux<String> 스트리밍으로 유지하기 위한 구현입니다.
-	 *
-	 * - consumes: application/json
-	 * - produces: text/plain (혹은 application/x-ndjson)
-	 *
-	 * 사용 예시:
-	 * Flux<String> chatStream = chatService.getChatResponse(request);
-	 * chatStream.subscribe(chunk -> {
-	 *     // 각 청크(chunk)마다 처리 로직 작성
-	 * });
-	 */
-
-	@Operation(
-			summary = "Chat streaming as plain text",
-			responses = {
-					@ApiResponse(
-							responseCode = "200",
-							description = "각 청크를 문자열로 스트리밍합니다.",
-							content = @Content(mediaType = MediaType.TEXT_PLAIN_VALUE)
-					)
-			}
-	)
 	@PostMapping(
 			consumes = MediaType.APPLICATION_JSON_VALUE,
-			produces = MediaType.TEXT_PLAIN_VALUE
+			produces = MediaType.TEXT_EVENT_STREAM_VALUE // 스트리밍용 Content-Type
 	)
-	public Flux<String> chat(@RequestBody ChatRequest req) {
+	public Flux<ServerSentEvent<String>> chat(@RequestBody ChatRequest req) {
 		return chatService.getChatResponse(req);
 	}
 
-	@Operation(
-			summary = "Chat likes-based recommendation streaming",
-			responses = {
-					@ApiResponse(
-							responseCode = "200",
-							description = "좋아요 기반 추천 결과를 스트리밍합니다.",
-							content = @Content(mediaType = MediaType.TEXT_PLAIN_VALUE)
-					)
-			}
-	)
 	@PostMapping(
 			value = "/likes",
 			consumes = MediaType.APPLICATION_JSON_VALUE,
-			produces = MediaType.TEXT_PLAIN_VALUE
+			produces = MediaType.TEXT_EVENT_STREAM_VALUE // 마찬가지로
 	)
-	public Flux<String> chatLikes(@RequestBody ChatLikesRequest req) {
+	public Flux<ServerSentEvent<String>> chatLikes(@RequestBody ChatLikesRequest req) {
 		ChatRequest request = new ChatRequest();
 		request.setSessionId(req.getSessionId());
-		request.setMessage("likes"); // 명시적으로 likes intent 전달
+		request.setMessage("likes");
 		return chatService.getChatLikesResponse(request);
 	}
 }
-
-
-

--- a/src/main/java/com/team4ever/backend/domain/ubti/controller/UBTIController.java
+++ b/src/main/java/com/team4ever/backend/domain/ubti/controller/UBTIController.java
@@ -7,6 +7,7 @@ import com.team4ever.backend.global.response.BaseResponse;
 import com.team4ever.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -21,9 +22,9 @@ public class UBTIController {
 	@PostMapping(
 			value = "/question",
 			consumes = MediaType.APPLICATION_JSON_VALUE,
-			produces = MediaType.TEXT_PLAIN_VALUE
+			produces = MediaType.TEXT_EVENT_STREAM_VALUE // 스트리밍 명시
 	)
-	public Flux<String> nextQuestion(@RequestBody UBTIRequest req) {
+	public Flux<ServerSentEvent<String>> nextQuestion(@RequestBody UBTIRequest req) {
 		return ubtiService.nextQuestionStream(req);
 	}
 
@@ -31,5 +32,4 @@ public class UBTIController {
 	public Mono<BaseResponse<UBTIResult>> finalResult(@RequestBody UBTIRequest req) {
 		return ubtiService.finalResultWrapped(req);
 	}
-
 }

--- a/src/main/java/com/team4ever/backend/domain/ubti/service/UBTIService.java
+++ b/src/main/java/com/team4ever/backend/domain/ubti/service/UBTIService.java
@@ -6,6 +6,7 @@ import com.team4ever.backend.global.exception.ErrorCode;
 import com.team4ever.backend.global.response.BaseResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
@@ -23,31 +24,27 @@ public class UBTIService {
 			@Value("${fastapi.ubti.host}") String host,
 			@Value("${fastapi.ubti.port}") int port,
 			@Value("${fastapi.ubti.path.question}") String questionPath,
-			@Value("${fastapi.ubti.path.result}")   String resultPath
+			@Value("${fastapi.ubti.path.result}") String resultPath
 	) {
 		this.webClient = webClientBuilder
 				.baseUrl(String.format("http://%s:%d", host, port))
 				.build();
 		this.questionPath = questionPath;
-		this.resultPath   = resultPath;
+		this.resultPath = resultPath;
 	}
 
-	/**
-	 * 질문 단계: UBTIQuestion 또는 UBTIComplete 리턴
-	 */
-	public Flux<String> nextQuestionStream(UBTIRequest req) {
+	public Flux<ServerSentEvent<String>> nextQuestionStream(UBTIRequest req) {
 		return webClient.post()
 				.uri(questionPath)
 				.contentType(MediaType.APPLICATION_JSON)
-				.accept(MediaType.TEXT_PLAIN) // 또는 NDJSON
+				.accept(MediaType.TEXT_EVENT_STREAM)  // 스트리밍 명시
 				.bodyValue(req)
 				.retrieve()
-				.bodyToFlux(String.class);
+				.bodyToFlux(String.class)
+				.map(data -> ServerSentEvent.builder(data).build());
 	}
 
-	/**
-	 * 최종 결과 단계: UBTIResult 리턴
-	 */
+	// 최종 결과 (단건, 스트리밍 아님)
 	public Mono<BaseResponse<UBTIResult>> finalResultWrapped(UBTIRequest req) {
 		return webClient.post()
 				.uri(resultPath)
@@ -55,7 +52,7 @@ public class UBTIService {
 				.bodyValue(req)
 				.retrieve()
 				.bodyToMono(UBTIResult.class)
-				.map(BaseResponse::success)
+				.map(data -> BaseResponse.success(data))
 				.onErrorResume(e -> Mono.just(BaseResponse.error(ErrorCode.INTERNAL_SERVER_ERROR)));
 	}
 }


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: Related to [EVER-118](https://github.com/Ureca-Middle-Project-Team4/4EVER0-FE/pull/23)

### 🔎 작업 내용

- [x] **SSE(Server-Sent Events) 기반 스트리밍 시스템 구축**
 - [x] 스프링부트 SSE 응답 형식으로 전면 수정
 - [x] 기존 REST API를 스트리밍 방식으로 변경

### 📸 스크린샷

### :loudspeaker: 전달사항

AI 응답까지 3-5초 대기 후 한 번에 수신하여 서비스가 멈춘 것처럼 느껴지는 문제가 있었습니다.
이번 리팩토링으로 메시지 전송 즉시 응답이 시작되고 글자가 하나씩 타이핑되어 더욱 자연스럽게 동작합니다!
따라서 프론트에서도 긴 응답도 안정적으로 스트리밍되며 청크 단위 처리로 메모리 효율성이 향상되었습니다.

#### 🏗️ 백엔드 SSE 구현 핵심

**SseEmitter 활용:**
```java
@GetMapping(value = "/chat", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
public SseEmitter streamChat(@RequestParam String message) {
   SseEmitter emitter = new SseEmitter();
   // 청크 단위로 응답 스트리밍
   return emitter;
}
```

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


[EVER-118]: https://youngxzu.atlassian.net/browse/EVER-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ