### PR TITLE
Feat: [EVER-130] 인증 기반 쿠폰 발급 API 구현

### DIFF
--- a/src/main/java/com/team4ever/backend/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/team4ever/backend/domain/coupon/controller/CouponController.java
@@ -41,7 +41,10 @@ public class CouponController {
         if (oAuth2User == null) {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
-
+        Object idAttr = oAuth2User.getAttribute("id");
+        if (idAttr == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
         Long userId = Long.valueOf(oAuth2User.getAttribute("id").toString());
         return BaseResponse.success(couponService.claimCoupon(userId, request.getCouponId()));
     }

--- a/src/main/java/com/team4ever/backend/domain/coupon/dto/CouponClaimRequest.java
+++ b/src/main/java/com/team4ever/backend/domain/coupon/dto/CouponClaimRequest.java
@@ -10,6 +10,6 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CouponClaimRequest {
-    private Integer userId;  // 나중에 SecurityContext 등으로 대체
     private Integer couponId;
+
 }

--- a/src/main/java/com/team4ever/backend/domain/coupon/entity/UserCoupon.java
+++ b/src/main/java/com/team4ever/backend/domain/coupon/entity/UserCoupon.java
@@ -5,8 +5,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.time.LocalDateTime;
-
 @Entity
 @Table(name = "user_coupons")
 @Getter
@@ -18,8 +16,8 @@ public class UserCoupon {
     @Column(columnDefinition = "INT UNSIGNED COMMENT '유저쿠폰 PK'")
     private Integer id;
 
-    @Column(columnDefinition = "INT UNSIGNED COMMENT '유저 FK'")
-    private Integer userId;
+    @Column(columnDefinition = "BIGINT UNSIGNED COMMENT '유저 FK'")
+    private Long userId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(
@@ -31,7 +29,7 @@ public class UserCoupon {
 
     private Boolean isUsed = false;
 
-    public static UserCoupon of(Integer userId, Coupon coupon) {
+    public static UserCoupon of(Long userId, Coupon coupon) {
         UserCoupon uc = new UserCoupon();
         uc.userId = userId;
         uc.coupon = coupon;

--- a/src/main/java/com/team4ever/backend/domain/coupon/repository/UserCouponRepository.java
+++ b/src/main/java/com/team4ever/backend/domain/coupon/repository/UserCouponRepository.java
@@ -10,9 +10,8 @@ import java.util.Optional;
 public interface UserCouponRepository extends JpaRepository<UserCoupon, Integer> {
     // 사용자+쿠폰 단건 조회 (사용 상태 확인)
     @EntityGraph(attributePaths = "coupon")
-    Optional<UserCoupon> findByUserIdAndCouponId(Integer userId, Integer couponId);
-
-    boolean existsByUserIdAndCouponId(Integer userId, Integer couponId);
+    Optional<UserCoupon> findByUserIdAndCouponId(Long userId, Integer couponId);
+    boolean existsByUserIdAndCouponId(Long userId, Integer couponId);
 
     // 사용자별 전체 쿠폰 조회 (isUsed 상태 확인)
     @EntityGraph(attributePaths = "coupon")

--- a/src/main/java/com/team4ever/backend/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/team4ever/backend/domain/coupon/service/CouponService.java
@@ -24,7 +24,7 @@ public class CouponService {
     private final UserCouponRepository userCouponRepository;
 
     @Transactional(readOnly = true)
-    public List<CouponResponse> getAllCoupons(Integer userId) {
+    public List<CouponResponse> getAllCoupons(Long userId) {
         LocalDate today = LocalDate.now();
         return couponRepository.findAllValid(today).stream()
                 .map(c -> {
@@ -38,7 +38,7 @@ public class CouponService {
     }
 
     @Transactional
-    public CouponClaimResponse claimCoupon(Integer userId, Integer couponId) {
+    public CouponClaimResponse claimCoupon(Long userId, Integer couponId) {
         var coupon = couponRepository.findById(couponId)
                 .orElseThrow(() -> new CustomException(ErrorCode.COUPON_NOT_FOUND));
 
@@ -56,7 +56,7 @@ public class CouponService {
     }
 
     @Transactional
-    public CouponUseResponse useCoupon(Integer userId, Integer couponId) {
+    public CouponUseResponse useCoupon(Long userId, Integer couponId) {
         UserCoupon uc = userCouponRepository.findByUserIdAndCouponId(userId, couponId)
                 .orElseThrow(() -> new CustomException(ErrorCode.COUPON_NOT_CLAIMED));
         if (uc.getIsUsed()) {


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #73 

### 🔎 작업 내용
- 쿠폰 발급 API에서 RequestBody로 userId 받지 않고, 인증된 사용자 정보에서 추출하도록 수정
- 테스트 중 Swagger 편의성 위해 userId 필드는 임시로 허용했지만 최종적으로 제거
- UserCoupon 및 관련 서비스/레포지토리 전반적으로 userId 타입을 Long으로 통일
- JWT 토큰이 없는 경우 401 응답 반환되도록 보안 강화

### 📸 스크린샷
- couponId 1을 발급 했을 때 데이터베이스에 잘 들어갔는지 테스트
- (참고) 4로 시작하는 user_id는 테스트한 제 아이디라 개인정보보호 위해서 뒤에 그림판으로 살짝 블러처리 했습니다 :)
<img width="1127" alt="image" src="https://github.com/user-attachments/assets/de2d31c9-373a-4576-8554-d41a6d15f2f6" />


### :loudspeaker: 전달사항
쿠폰 사용하는 api도 구현하겠습니다~

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
