### PR TITLE
Feat: [EVER-137] 내 구독 상품 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/team4ever/backend/BackendApplication.java
+++ b/src/main/java/com/team4ever/backend/BackendApplication.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 		basePackages = {
 				"com.team4ever.backend.domain.common.brand",
 				// 필요하다면 여기에 다른 레포지토리 패키지 추가
+				"com.team4ever.backend.domain.benefit.repository",
 				"com.team4ever.backend.domain.attendance.repository",
 				"com.team4ever.backend.domain.coupon.repository",
 				"com.team4ever.backend.domain.popups.repository",

--- a/src/main/java/com/team4ever/backend/domain/benefit/controller/BenefitController.java
+++ b/src/main/java/com/team4ever/backend/domain/benefit/controller/BenefitController.java
@@ -1,0 +1,31 @@
+package com.team4ever.backend.domain.benefit.controller;
+
+import com.team4ever.backend.domain.benefit.dto.BenefitResponse;
+import com.team4ever.backend.domain.benefit.service.BenefitService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import java.time.LocalDate;
+import java.util.List;
+import com.team4ever.backend.domain.benefit.dto.BenefitApiResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/uplus-benefits")
+public class BenefitController {
+
+    private final BenefitService benefitService;
+
+    @GetMapping
+    public BenefitApiResponse<List<BenefitResponse>> getAllBenefits() {
+        return BenefitApiResponse.ok("요청이 성공적으로 처리되었습니다.", benefitService.getAllBenefits());
+    }
+
+    @GetMapping(params = "date")
+    public BenefitApiResponse<List<BenefitResponse>> getBenefitsByDate(@RequestParam String date) {
+        LocalDate parsedDate = LocalDate.parse(date);
+        return BenefitApiResponse.ok("요청이 성공적으로 처리되었습니다.", benefitService.getBenefitsByDate(parsedDate));
+    }
+}

--- a/src/main/java/com/team4ever/backend/domain/benefit/dto/BenefitApiResponse.java
+++ b/src/main/java/com/team4ever/backend/domain/benefit/dto/BenefitApiResponse.java
@@ -1,0 +1,16 @@
+package com.team4ever.backend.domain.benefit.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BenefitApiResponse<T> {
+    private int status;
+    private String message;
+    private T data;
+
+    public static <T> BenefitApiResponse<T> ok(String message, T data) {
+        return new BenefitApiResponse<>(200, message, data);
+    }
+}

--- a/src/main/java/com/team4ever/backend/domain/benefit/dto/BenefitResponse.java
+++ b/src/main/java/com/team4ever/backend/domain/benefit/dto/BenefitResponse.java
@@ -1,0 +1,18 @@
+package com.team4ever.backend.domain.benefit.dto;
+
+import com.team4ever.backend.domain.benefit.entity.Benefit;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class BenefitResponse {
+
+    private String brand;
+    private LocalDate date;
+
+    public static BenefitResponse from(Benefit benefit) {
+        return new BenefitResponse(benefit.getBrand(), benefit.getDate());
+    }
+}

--- a/src/main/java/com/team4ever/backend/domain/benefit/entity/Benefit.java
+++ b/src/main/java/com/team4ever/backend/domain/benefit/entity/Benefit.java
@@ -1,0 +1,22 @@
+package com.team4ever.backend.domain.benefit.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Benefit {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String brand;
+
+    private LocalDate date;
+}

--- a/src/main/java/com/team4ever/backend/domain/benefit/repository/BenefitRepository.java
+++ b/src/main/java/com/team4ever/backend/domain/benefit/repository/BenefitRepository.java
@@ -2,10 +2,12 @@ package com.team4ever.backend.domain.benefit.repository;
 
 import com.team4ever.backend.domain.benefit.entity.Benefit;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
 
+@Repository
 public interface BenefitRepository extends JpaRepository<Benefit, Long> {
     List<Benefit> findAllByDate(LocalDate date);
 }

--- a/src/main/java/com/team4ever/backend/domain/benefit/repository/BenefitRepository.java
+++ b/src/main/java/com/team4ever/backend/domain/benefit/repository/BenefitRepository.java
@@ -1,0 +1,11 @@
+package com.team4ever.backend.domain.benefit.repository;
+
+import com.team4ever.backend.domain.benefit.entity.Benefit;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface BenefitRepository extends JpaRepository<Benefit, Long> {
+    List<Benefit> findAllByDate(LocalDate date);
+}

--- a/src/main/java/com/team4ever/backend/domain/benefit/service/BenefitService.java
+++ b/src/main/java/com/team4ever/backend/domain/benefit/service/BenefitService.java
@@ -1,0 +1,30 @@
+package com.team4ever.backend.domain.benefit.service;
+
+import com.team4ever.backend.domain.benefit.dto.BenefitResponse;
+import com.team4ever.backend.domain.benefit.entity.Benefit;
+import com.team4ever.backend.domain.benefit.repository.BenefitRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class BenefitService {
+
+    private final BenefitRepository benefitRepository;
+
+    public List<BenefitResponse> getAllBenefits() {
+        return benefitRepository.findAll().stream()
+                .map(BenefitResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    public List<BenefitResponse> getBenefitsByDate(LocalDate date) {
+        return benefitRepository.findAllByDate(date).stream()
+                .map(BenefitResponse::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/team4ever/backend/domain/popups/controller/PopupController.java
+++ b/src/main/java/com/team4ever/backend/domain/popups/controller/PopupController.java
@@ -16,16 +16,21 @@ public class PopupController {
 
     private final PopupService popupService;
 
+    /**
+     * 팝업스토어 전체 조회
+     */
     @GetMapping
     public ResponseEntity<BaseResponse<List<PopupResponse>>> getAllPopups() {
         List<PopupResponse> result = popupService.getAllPopups();
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 
+    /**
+     * 팝업스토어 ID로 조회
+     */
     @GetMapping("/{id}")
-    public ResponseEntity<BaseResponse<PopupResponse>> getPopupById(@PathVariable Long id) {
+    public ResponseEntity<BaseResponse<PopupResponse>> getPopupById(@PathVariable Integer id) {
         PopupResponse result = popupService.getPopupById(id);
         return ResponseEntity.ok(BaseResponse.success(result));
-
     }
 }

--- a/src/main/java/com/team4ever/backend/domain/popups/dto/PopupResponse.java
+++ b/src/main/java/com/team4ever/backend/domain/popups/dto/PopupResponse.java
@@ -1,17 +1,19 @@
 package com.team4ever.backend.domain.popups.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
 public class PopupResponse {
-    private Long id;
+    private Integer id;
     private String name;
     private String description;
     private String address;
     private Double latitude;
     private Double longitude;
+
+    @JsonProperty("image_url")
     private String imageUrl;
 }
-

--- a/src/main/java/com/team4ever/backend/domain/popups/repository/PopupRepository.java
+++ b/src/main/java/com/team4ever/backend/domain/popups/repository/PopupRepository.java
@@ -2,9 +2,9 @@ package com.team4ever.backend.domain.popups.repository;
 
 import com.team4ever.backend.domain.popups.entity.Popup;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
+@Repository
 public interface PopupRepository extends JpaRepository<Popup, Integer> {
-    List<Popup> findAllByUserId(Integer userId);
+    // 기본 CRUD 메서드는 JpaRepository에서 제공
 }

--- a/src/main/java/com/team4ever/backend/domain/popups/service/PopupService.java
+++ b/src/main/java/com/team4ever/backend/domain/popups/service/PopupService.java
@@ -19,22 +19,29 @@ public class PopupService {
 
     private final PopupRepository popupRepository;
 
-    /** 전체 조회 */
+    /**
+     * 팝업스토어 전체 조회
+     */
     public List<PopupResponse> getAllPopups() {
         return popupRepository.findAll().stream()
                 .map(this::toResponse)
                 .collect(Collectors.toList());
     }
 
-    /** ID로 조회 */
+    /**
+     * 팝업스토어 ID로 조회
+     */
     public PopupResponse getPopupById(Integer id) {
         Popup popup = popupRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.POPUP_NOT_FOUND));
         return toResponse(popup);
     }
 
+    /**
+     * Popup 엔티티를 PopupResponse DTO로 변환
+     */
     private PopupResponse toResponse(Popup popup) {
-        // description의 \n을 공백으로 치환해야 함
+        // description의 \n을 공백으로 치환
         String cleanedDescription = popup.getDescription() != null
                 ? popup.getDescription().replace("\n", " ")
                 : "";
@@ -49,5 +56,4 @@ public class PopupService {
                 .imageUrl(popup.getImageUrl())
                 .build();
     }
-
 }

--- a/src/main/java/com/team4ever/backend/domain/subscriptions/repository/UserSubscriptionCombinationRepository.java
+++ b/src/main/java/com/team4ever/backend/domain/subscriptions/repository/UserSubscriptionCombinationRepository.java
@@ -1,13 +1,40 @@
 package com.team4ever.backend.domain.subscriptions.repository;
 
 import com.team4ever.backend.domain.subscriptions.entity.UserSubscriptionCombination;
+import com.team4ever.backend.domain.user.dto.UserSubscriptionDto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface UserSubscriptionCombinationRepository extends JpaRepository<UserSubscriptionCombination, Integer> {
+
+	// 기존 메서드들
 	boolean existsByUserIdAndSubscriptionCombinationId(Long userId, Integer subscriptionCombinationId);
 	Optional<UserSubscriptionCombination> findByUserIdAndSubscriptionCombinationId(Long userId, Integer subscriptionCombinationId);
+
+	// 사용자 구독 목록 조회 (구독 상품명 + 브랜드명)
+	@Query("""
+        SELECT new com.team4ever.backend.domain.user.dto.UserSubscriptionDto(
+            usc.id,
+            s.title,
+            b.name,
+            usc.price,
+            usc.createdAt
+        )
+        FROM UserSubscriptionCombination usc
+        JOIN SubscriptionCombination sc ON usc.subscriptionCombinationId = sc.id
+        JOIN Subscription s ON sc.subscriptionId = s.id
+        JOIN Brand b ON sc.brandId = b.id
+        WHERE usc.userId = :userId
+        ORDER BY usc.createdAt DESC
+    """)
+	List<UserSubscriptionDto> findUserSubscriptionsWithDetails(@Param("userId") Long userId);
+
+	// 사용자의 총 구독 수 조회
+	long countByUserId(Long userId);
 }

--- a/src/main/java/com/team4ever/backend/domain/subscriptions/repository/UserSubscriptionCombinationRepository.java
+++ b/src/main/java/com/team4ever/backend/domain/subscriptions/repository/UserSubscriptionCombinationRepository.java
@@ -13,11 +13,9 @@ import java.util.Optional;
 @Repository
 public interface UserSubscriptionCombinationRepository extends JpaRepository<UserSubscriptionCombination, Integer> {
 
-	// 기존 메서드들
 	boolean existsByUserIdAndSubscriptionCombinationId(Long userId, Integer subscriptionCombinationId);
 	Optional<UserSubscriptionCombination> findByUserIdAndSubscriptionCombinationId(Long userId, Integer subscriptionCombinationId);
 
-	// 사용자 구독 목록 조회 (구독 상품명 + 브랜드명)
 	@Query("""
         SELECT new com.team4ever.backend.domain.user.dto.UserSubscriptionDto(
             usc.id,
@@ -35,6 +33,5 @@ public interface UserSubscriptionCombinationRepository extends JpaRepository<Use
     """)
 	List<UserSubscriptionDto> findUserSubscriptionsWithDetails(@Param("userId") Long userId);
 
-	// 사용자의 총 구독 수 조회
 	long countByUserId(Long userId);
 }

--- a/src/main/java/com/team4ever/backend/domain/user/Controller/UserController.java
+++ b/src/main/java/com/team4ever/backend/domain/user/Controller/UserController.java
@@ -1,10 +1,13 @@
 package com.team4ever.backend.domain.user.Controller;
 
 import com.team4ever.backend.domain.user.Service.UserService;
+import com.team4ever.backend.domain.user.dto.CreateUserRequest;
+import com.team4ever.backend.domain.user.dto.UserResponse;
 import com.team4ever.backend.domain.user.dto.UserSubscriptionListResponse;
 import com.team4ever.backend.global.exception.CustomException;
 import com.team4ever.backend.global.exception.ErrorCode;
 import com.team4ever.backend.global.response.BaseResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -16,7 +19,25 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class UserController {
 
-    private final UserService userService; // UserService 인터페이스 주입
+    private final UserService svc;
+
+    // 신규 회원 생성
+    @PostMapping
+    public ResponseEntity<Long> createUser(
+            @Valid @RequestBody CreateUserRequest req
+    ) {
+        Long id = svc.createUser(req);
+        return ResponseEntity.ok(id);
+    }
+
+    // userId로 회원 정보 조회
+    @GetMapping
+    public ResponseEntity<UserResponse> getUser(
+            @RequestParam("userId") String userId
+    ) {
+        UserResponse dto = svc.getUserByUserId(userId);
+        return ResponseEntity.ok(dto);
+    }
 
     /**
      * 내 구독 상품 목록 조회
@@ -31,7 +52,7 @@ public class UserController {
 
         String oauthUserId = oAuth2User.getAttribute("id").toString();
 
-        UserSubscriptionListResponse response = userService.getUserSubscriptions(oauthUserId);
+        UserSubscriptionListResponse response = svc.getUserSubscriptions(oauthUserId); // userService → svc로 변경!
         return ResponseEntity.ok(BaseResponse.success(response));
     }
 }

--- a/src/main/java/com/team4ever/backend/domain/user/Controller/UserController.java
+++ b/src/main/java/com/team4ever/backend/domain/user/Controller/UserController.java
@@ -1,38 +1,37 @@
-// src/main/java/com/team4ever/backend/user/controller/UserController.java
 package com.team4ever.backend.domain.user.Controller;
 
-import com.team4ever.backend.domain.user.dto.CreateUserRequest;
-import com.team4ever.backend.domain.user.dto.UserResponse;
 import com.team4ever.backend.domain.user.Service.UserService;
-import jakarta.validation.Valid;
+import com.team4ever.backend.domain.user.dto.UserSubscriptionListResponse;
+import com.team4ever.backend.global.exception.CustomException;
+import com.team4ever.backend.global.exception.ErrorCode;
+import com.team4ever.backend.global.response.BaseResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/users")
+@RequestMapping("/api/user")
+@RequiredArgsConstructor
 public class UserController {
 
-    private final UserService svc;
+    private final UserService userService; // UserService 인터페이스 주입
 
-    public UserController(UserService svc) {
-        this.svc = svc;
-    }
-
-    // 신규 회원 생성
-    @PostMapping
-    public ResponseEntity<Long> createUser(
-            @Valid @RequestBody CreateUserRequest req
+    /**
+     * 내 구독 상품 목록 조회
+     */
+    @GetMapping("/subscriptions")
+    public ResponseEntity<BaseResponse<UserSubscriptionListResponse>> getUserSubscriptions(
+            @AuthenticationPrincipal OAuth2User oAuth2User
     ) {
-        Long id = svc.createUser(req);
-        return ResponseEntity.ok(id);
-    }
+        if (oAuth2User == null || oAuth2User.getAttribute("id") == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
 
-    // userId로 회원 정보 조회
-    @GetMapping
-    public ResponseEntity<UserResponse> getUser(
-            @RequestParam("userId") String userId
-    ) {
-        UserResponse dto = svc.getUserByUserId(userId);
-        return ResponseEntity.ok(dto);
+        String oauthUserId = oAuth2User.getAttribute("id").toString();
+
+        UserSubscriptionListResponse response = userService.getUserSubscriptions(oauthUserId);
+        return ResponseEntity.ok(BaseResponse.success(response));
     }
 }

--- a/src/main/java/com/team4ever/backend/domain/user/Service/UserService.java
+++ b/src/main/java/com/team4ever/backend/domain/user/Service/UserService.java
@@ -1,9 +1,14 @@
 package com.team4ever.backend.domain.user.Service;
 
 import com.team4ever.backend.domain.user.dto.CreateUserRequest;
-import com.team4ever.backend.domain.user.dto.UserResponse;
+import com.team4ever.backend.domain.user.dto.UserSubscriptionListResponse;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface UserService {
     Long createUser(CreateUserRequest req);
-    UserResponse getUserByUserId(String userId);
+    void getUserByUserId(String userId);
+
+	// 새로 추가: 사용자 구독 목록 조회
+	@Transactional(readOnly = true)
+	UserSubscriptionListResponse getUserSubscriptions(String oauthUserId);
 }

--- a/src/main/java/com/team4ever/backend/domain/user/Service/UserService.java
+++ b/src/main/java/com/team4ever/backend/domain/user/Service/UserService.java
@@ -1,14 +1,11 @@
 package com.team4ever.backend.domain.user.Service;
 
 import com.team4ever.backend.domain.user.dto.CreateUserRequest;
+import com.team4ever.backend.domain.user.dto.UserResponse;
 import com.team4ever.backend.domain.user.dto.UserSubscriptionListResponse;
-import org.springframework.transaction.annotation.Transactional;
 
 public interface UserService {
-    Long createUser(CreateUserRequest req);
-    void getUserByUserId(String userId);
-
-	// 새로 추가: 사용자 구독 목록 조회
-	@Transactional(readOnly = true)
+	Long createUser(CreateUserRequest req);
+	UserResponse getUserByUserId(String userId);
 	UserSubscriptionListResponse getUserSubscriptions(String oauthUserId);
 }

--- a/src/main/java/com/team4ever/backend/domain/user/Service/UserServiceImpl.java
+++ b/src/main/java/com/team4ever/backend/domain/user/Service/UserServiceImpl.java
@@ -54,11 +54,12 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional(readOnly = true)
-    public void getUserByUserId(String userId) {
+    public UserResponse getUserByUserId(String userId) { // void → UserResponse로 수정
         User u = repo.findByUserId(userId)
                 //Exception 나중에 정의해서 바꾸기
                 .orElseThrow(() -> new IllegalArgumentException("해당 userId를 찾을 수 없습니다."));
-        UserResponse.builder()
+
+        return UserResponse.builder() // return 추가
                 .id(u.getId())
                 .planId(u.getPlanId())
                 .userId(u.getUserId())
@@ -72,8 +73,8 @@ public class UserServiceImpl implements UserService {
     }
 
     // 사용자 구독 목록 조회
-    @Transactional(readOnly = true)
     @Override
+    @Transactional(readOnly = true)
     public UserSubscriptionListResponse getUserSubscriptions(String oauthUserId) {
         try {
             log.info("사용자 구독 목록 조회 시작 - oauthUserId: {}", oauthUserId);

--- a/src/main/java/com/team4ever/backend/domain/user/Service/UserServiceImpl.java
+++ b/src/main/java/com/team4ever/backend/domain/user/Service/UserServiceImpl.java
@@ -2,19 +2,31 @@ package com.team4ever.backend.domain.user.Service;
 
 import com.team4ever.backend.domain.user.dto.CreateUserRequest;
 import com.team4ever.backend.domain.user.dto.UserResponse;
+import com.team4ever.backend.domain.user.dto.UserSubscriptionDto;
+import com.team4ever.backend.domain.user.dto.UserSubscriptionListResponse;
 import com.team4ever.backend.domain.user.Entity.User;
 import com.team4ever.backend.domain.user.repository.UserRepository;
+import com.team4ever.backend.domain.subscriptions.repository.UserSubscriptionCombinationRepository;
+import com.team4ever.backend.global.exception.CustomException;
+import com.team4ever.backend.global.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
+@Slf4j
 @Service
 @Transactional
 public class UserServiceImpl implements UserService {
     private static final int DEFAULT_PLAN_ID = 0;
-    private final UserRepository repo;
 
-    public UserServiceImpl(UserRepository repo) {
+    private final UserRepository repo;
+    private final UserSubscriptionCombinationRepository userSubscriptionCombinationRepository;
+
+    public UserServiceImpl(UserRepository repo, UserSubscriptionCombinationRepository userSubscriptionCombinationRepository) {
         this.repo = repo;
+        this.userSubscriptionCombinationRepository = userSubscriptionCombinationRepository;
     }
 
     @Override
@@ -42,11 +54,11 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional(readOnly = true)
-    public UserResponse getUserByUserId(String userId) {
+    public void getUserByUserId(String userId) {
         User u = repo.findByUserId(userId)
                 //Exception 나중에 정의해서 바꾸기
                 .orElseThrow(() -> new IllegalArgumentException("해당 userId를 찾을 수 없습니다."));
-        return UserResponse.builder()
+        UserResponse.builder()
                 .id(u.getId())
                 .planId(u.getPlanId())
                 .userId(u.getUserId())
@@ -57,5 +69,42 @@ public class UserServiceImpl implements UserService {
                 .attendanceStreak(u.getAttendanceStreak())
                 .point(u.getPoint())
                 .build();
+    }
+
+    // 사용자 구독 목록 조회
+    @Transactional(readOnly = true)
+    @Override
+    public UserSubscriptionListResponse getUserSubscriptions(String oauthUserId) {
+        try {
+            log.info("사용자 구독 목록 조회 시작 - oauthUserId: {}", oauthUserId);
+
+            // 사용자 조회
+            User currentUser = repo.findByUserId(oauthUserId)
+                    .orElseThrow(() -> {
+                        log.error("사용자를 찾을 수 없습니다. oauthUserId: {}", oauthUserId);
+                        return new CustomException(ErrorCode.USER_NOT_FOUND);
+                    });
+
+            Long userId = currentUser.getId();
+            log.info("조회 요청 사용자 PK: {}", userId);
+
+            // 구독 목록 조회
+            List<UserSubscriptionDto> subscriptions = userSubscriptionCombinationRepository
+                    .findUserSubscriptionsWithDetails(userId);
+
+            log.info("사용자 구독 목록 조회 완료 - userId: {}, 구독 수: {}", userId, subscriptions.size());
+
+            return UserSubscriptionListResponse.builder()
+                    .total(subscriptions.size())
+                    .combinations(subscriptions)
+                    .build();
+
+        } catch (CustomException e) {
+            log.error("사용자 구독 목록 조회 중 알려진 오류 발생: {}", e.getMessage(), e);
+            throw e;
+        } catch (Exception e) {
+            log.error("사용자 구독 목록 조회 중 예상치 못한 오류 발생", e);
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
     }
 }

--- a/src/main/java/com/team4ever/backend/domain/user/dto/UserSubscriptionDto.java
+++ b/src/main/java/com/team4ever/backend/domain/user/dto/UserSubscriptionDto.java
@@ -1,0 +1,24 @@
+package com.team4ever.backend.domain.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class UserSubscriptionDto {
+	private Integer id;
+
+	@JsonProperty("main_title")
+	private String mainTitle;
+
+	@JsonProperty("brand_title")
+	private String brandTitle;
+
+	private Integer price;
+
+	@JsonProperty("created_at")
+	private LocalDateTime createdAt;
+}

--- a/src/main/java/com/team4ever/backend/domain/user/dto/UserSubscriptionListResponse.java
+++ b/src/main/java/com/team4ever/backend/domain/user/dto/UserSubscriptionListResponse.java
@@ -1,0 +1,13 @@
+package com.team4ever.backend.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class UserSubscriptionListResponse {
+	private Integer total;
+	private List<UserSubscriptionDto> combinations;
+}


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #81 

### 🔎 작업 내용

- [x]  **GET** `/api/user/subscriptions` 사용자 구독 목록 조회 API 구현
  - [x]  구독 상품명과 브랜드명을 포함한 JOIN 쿼리 최적화: 한 번의 쿼리로 모든 데이터 조회 가능 `UserSubscriptionCombinationRepository` 레포지토리 파일 참고
  - [x]  구독이 없는 경우 빈 배열 반환

### 📸 스크린샷
> 구독 상품 있으면 조회 가능
![스크린샷 2025-06-12 오후 1 13 56](https://github.com/user-attachments/assets/15822865-352d-4b27-868a-a881903c66ce)

> 없으면 빈 배열로 반환
![image](https://github.com/user-attachments/assets/5c334187-edea-4e02-8e80-1c6e0f21f6ea)

### :loudspeaker: 전달사항
> 머지하면서 유플투쁠(Benefit) 레포지토리도 추가해뒀습니다~

- 추가한 라이브러리나 특이 사항

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
