### PR TITLE
Feat: [EVER-141] 수동 좌표 기반 근처 팝업스토어 조회, IP 위치 기반 내 주변 팝업스토어 조회 API 구현

### DIFF
--- a/src/main/java/com/team4ever/backend/domain/popups/controller/PopupController.java
+++ b/src/main/java/com/team4ever/backend/domain/popups/controller/PopupController.java
@@ -40,7 +40,8 @@ public class PopupController {
     }
 
     /**
-     * 수동 좌표로 근처 팝업스토어 조회 (클라리언ㅌ
+     * 수동 좌표로 근처 팝업스토어 조회
+     * - 예시: GET /api/popups/nearby?lat=37.5665&lng=126.9780&radius=5.0
      */
     @GetMapping("/nearby")
     public ResponseEntity<BaseResponse<List<NearbyPopupResponse>>> getNearbyPopups(
@@ -48,17 +49,21 @@ public class PopupController {
             @RequestParam Double lng,
             @RequestParam(defaultValue = "5.0") Double radius
     ) {
+        log.info("수동 좌표 기반 근처 팝업스토어 조회 - lat: {}, lng: {}, radius: {}km", lat, lng, radius);
+
         NearbyPopupsRequest request = new NearbyPopupsRequest();
         request.setLat(lat);
         request.setLng(lng);
         request.setRadius(radius);
 
         List<NearbyPopupResponse> results = popupService.getNearbyPopups(request);
+
+        log.info("수동 좌표 기반 조회 완료 - 검색된 팝업스토어 수: {}", results.size());
         return ResponseEntity.ok(BaseResponse.success(results));
     }
 
     /**
-     * 🎯 IP 기반 자동 위치로 근처 팝업스토어 조회
+     * IP 기반 자동 위치로 근처 팝업스토어 조회
      */
     @GetMapping("/nearby/location")
     public ResponseEntity<BaseResponse<UserLocationResponse>> getNearbyPopupsAuto(

--- a/src/main/java/com/team4ever/backend/domain/popups/controller/PopupController.java
+++ b/src/main/java/com/team4ever/backend/domain/popups/controller/PopupController.java
@@ -1,22 +1,25 @@
 package com.team4ever.backend.domain.popups.controller;
 
-import com.team4ever.backend.domain.popups.dto.NearbyPopupResponse;
-import com.team4ever.backend.domain.popups.dto.NearbyPopupsRequest;
-import com.team4ever.backend.domain.popups.dto.PopupResponse;
+import com.team4ever.backend.domain.popups.dto.*;
 import com.team4ever.backend.domain.popups.service.PopupService;
+import com.team4ever.backend.domain.popups.service.GeolocationService;
 import com.team4ever.backend.global.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/popups")
 @RequiredArgsConstructor
 public class PopupController {
 
     private final PopupService popupService;
+    private final GeolocationService geolocationService;
 
     /**
      * 팝업스토어 전체 조회
@@ -37,7 +40,7 @@ public class PopupController {
     }
 
     /**
-     * 근처 팝업스토어 조회
+     * 수동 좌표로 근처 팝업스토어 조회 (클라리언ㅌ
      */
     @GetMapping("/nearby")
     public ResponseEntity<BaseResponse<List<NearbyPopupResponse>>> getNearbyPopups(
@@ -52,5 +55,112 @@ public class PopupController {
 
         List<NearbyPopupResponse> results = popupService.getNearbyPopups(request);
         return ResponseEntity.ok(BaseResponse.success(results));
+    }
+
+    /**
+     * 🎯 IP 기반 자동 위치로 근처 팝업스토어 조회
+     */
+    @GetMapping("/nearby/location")
+    public ResponseEntity<BaseResponse<UserLocationResponse>> getNearbyPopupsAuto(
+            HttpServletRequest request,
+            @RequestParam(defaultValue = "5.0") Double radius
+    ) {
+        try {
+            // 1. 클라이언트 IP 추출
+            String clientIp = getClientIp(request);
+            log.info("클라이언트 IP: {}", clientIp);
+
+            // 2. IP 기반 위치 조회
+            GeolocationResponse geolocation = geolocationService.getLocationByIp(clientIp);
+            GeolocationResponse.GeoLocationData location = geolocation.getGeoLocation();
+
+            log.info("조회된 위치 - lat: {}, lng: {}, 주소: {} {} {}",
+                    location.getLat(), location.getLongitude(),
+                    location.getR1(), location.getR2(), location.getR3());
+
+            // 3. 근처 팝업스토어 조회
+            NearbyPopupsRequest nearbyRequest = new NearbyPopupsRequest();
+            nearbyRequest.setLat(location.getLat());
+            nearbyRequest.setLng(location.getLongitude());
+            nearbyRequest.setRadius(radius);
+
+            List<NearbyPopupResponse> nearbyPopups = popupService.getNearbyPopups(nearbyRequest);
+
+            // 4. 통합 응답 생성
+            UserLocationResponse response = UserLocationResponse.builder()
+                    .latitude(location.getLat())
+                    .longitude(location.getLongitude())
+                    .address(String.format("%s %s %s",
+                            location.getR1() != null ? location.getR1() : "",
+                            location.getR2() != null ? location.getR2() : "",
+                            location.getR3() != null ? location.getR3() : "").trim())
+                    .nearbyPopups(nearbyPopups)
+                    .build();
+
+            return ResponseEntity.ok(BaseResponse.success(response));
+
+        } catch (Exception e) {
+            log.error("자동 위치 기반 팝업스토어 조회 실패", e);
+
+            // 5. 실패 시 기본 위치 사용
+            return getNearbyPopupsWithDefaultLocation(radius);
+        }
+    }
+
+    /**
+     * 기본 위치로 폴백
+     */
+    private ResponseEntity<BaseResponse<UserLocationResponse>> getNearbyPopupsWithDefaultLocation(Double radius) {
+        log.info("기본 위치 사용");
+
+        // 선릉 멀티캠퍼스 좌표
+        double defaultLat = 37.503298369423;
+        double defaultLng = 127.04979962846;
+
+        NearbyPopupsRequest nearbyRequest = new NearbyPopupsRequest();
+        nearbyRequest.setLat(defaultLat);
+        nearbyRequest.setLng(defaultLng);
+        nearbyRequest.setRadius(radius);
+
+        List<NearbyPopupResponse> nearbyPopups = popupService.getNearbyPopups(nearbyRequest);
+
+        UserLocationResponse response = UserLocationResponse.builder()
+                .latitude(defaultLat)
+                .longitude(defaultLng)
+                .address("서울특별시 강남구 선릉로 428 (기본 위치)")
+                .nearbyPopups(nearbyPopups)
+                .build();
+
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    /**
+     * 클라이언트 실제 IP 주소 추출
+     */
+    private String getClientIp(HttpServletRequest request) {
+        String clientIp = request.getHeader("X-Forwarded-For");
+
+        if (clientIp == null || clientIp.isEmpty() || "unknown".equalsIgnoreCase(clientIp)) {
+            clientIp = request.getHeader("Proxy-Client-IP");
+        }
+        if (clientIp == null || clientIp.isEmpty() || "unknown".equalsIgnoreCase(clientIp)) {
+            clientIp = request.getHeader("WL-Proxy-Client-IP");
+        }
+        if (clientIp == null || clientIp.isEmpty() || "unknown".equalsIgnoreCase(clientIp)) {
+            clientIp = request.getHeader("HTTP_CLIENT_IP");
+        }
+        if (clientIp == null || clientIp.isEmpty() || "unknown".equalsIgnoreCase(clientIp)) {
+            clientIp = request.getHeader("HTTP_X_FORWARDED_FOR");
+        }
+        if (clientIp == null || clientIp.isEmpty() || "unknown".equalsIgnoreCase(clientIp)) {
+            clientIp = request.getRemoteAddr();
+        }
+
+        // 여러 IP가 있는 경우 첫 번째 IP 사용
+        if (clientIp != null && clientIp.contains(",")) {
+            clientIp = clientIp.split(",")[0].trim();
+        }
+
+        return clientIp;
     }
 }

--- a/src/main/java/com/team4ever/backend/domain/popups/controller/PopupController.java
+++ b/src/main/java/com/team4ever/backend/domain/popups/controller/PopupController.java
@@ -1,5 +1,7 @@
 package com.team4ever.backend.domain.popups.controller;
 
+import com.team4ever.backend.domain.popups.dto.NearbyPopupResponse;
+import com.team4ever.backend.domain.popups.dto.NearbyPopupsRequest;
 import com.team4ever.backend.domain.popups.dto.PopupResponse;
 import com.team4ever.backend.domain.popups.service.PopupService;
 import com.team4ever.backend.global.response.BaseResponse;
@@ -32,5 +34,23 @@ public class PopupController {
     public ResponseEntity<BaseResponse<PopupResponse>> getPopupById(@PathVariable Integer id) {
         PopupResponse result = popupService.getPopupById(id);
         return ResponseEntity.ok(BaseResponse.success(result));
+    }
+
+    /**
+     * 근처 팝업스토어 조회
+     */
+    @GetMapping("/nearby")
+    public ResponseEntity<BaseResponse<List<NearbyPopupResponse>>> getNearbyPopups(
+            @RequestParam Double lat,
+            @RequestParam Double lng,
+            @RequestParam(defaultValue = "5.0") Double radius
+    ) {
+        NearbyPopupsRequest request = new NearbyPopupsRequest();
+        request.setLat(lat);
+        request.setLng(lng);
+        request.setRadius(radius);
+
+        List<NearbyPopupResponse> results = popupService.getNearbyPopups(request);
+        return ResponseEntity.ok(BaseResponse.success(results));
     }
 }

--- a/src/main/java/com/team4ever/backend/domain/popups/dto/GeolocationResponse.java
+++ b/src/main/java/com/team4ever/backend/domain/popups/dto/GeolocationResponse.java
@@ -1,0 +1,51 @@
+package com.team4ever.backend.domain.popups.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class GeolocationResponse {
+
+	@JsonProperty("returnCode")
+	private String returnCode;
+
+	@JsonProperty("requestId")
+	private String requestId;
+
+	@JsonProperty("geoLocation")
+	private GeoLocationData geoLocation;
+
+	@Getter
+	@Setter
+	public static class GeoLocationData {
+		@JsonProperty("country")
+		private String country;
+
+		@JsonProperty("code")
+		private String code;
+
+		@JsonProperty("r1")
+		private String r1; // 시/도
+
+		@JsonProperty("r2")
+		private String r2; // 시/구/군
+
+		@JsonProperty("r3")
+		private String r3; // 동/면/읍
+
+		@JsonProperty("lat")
+		private Double lat; // 위도
+
+		@JsonProperty("long")
+		private Double longitude; // 경도
+
+		@JsonProperty("net")
+		private String net; // 통신사
+
+		public Double getLng() {
+			return longitude;
+		}
+	}
+}

--- a/src/main/java/com/team4ever/backend/domain/popups/dto/NearbyPopupResponse.java
+++ b/src/main/java/com/team4ever/backend/domain/popups/dto/NearbyPopupResponse.java
@@ -1,0 +1,22 @@
+package com.team4ever.backend.domain.popups.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NearbyPopupResponse {
+	private Integer id;
+	private String name;
+	private String description;
+	private String address;
+	private Double latitude;
+	private Double longitude;
+
+	@JsonProperty("image_url")
+	private String imageUrl;
+
+	@JsonProperty("distance_km")
+	private Double distanceKm;
+}

--- a/src/main/java/com/team4ever/backend/domain/popups/dto/NearbyPopupsRequest.java
+++ b/src/main/java/com/team4ever/backend/domain/popups/dto/NearbyPopupsRequest.java
@@ -1,0 +1,26 @@
+package com.team4ever.backend.domain.popups.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+
+@Getter
+@Setter
+public class NearbyPopupsRequest {
+
+	@NotNull(message = "위도는 필수입니다.")
+	@DecimalMin(value = "-90.0", message = "위도는 -90 이상이어야 합니다.")
+	@DecimalMax(value = "90.0", message = "위도는 90 이하여야 합니다.")
+	private Double lat;
+
+	@NotNull(message = "경도는 필수입니다.")
+	@DecimalMin(value = "-180.0", message = "경도는 -180 이상이어야 합니다.")
+	@DecimalMax(value = "180.0", message = "경도는 180 이하여야 합니다.")
+	private Double lng;
+
+	// 검색 반경 (기본값: 5km)
+	private Double radius = 5.0;
+}

--- a/src/main/java/com/team4ever/backend/domain/popups/dto/UserLocationResponse.java
+++ b/src/main/java/com/team4ever/backend/domain/popups/dto/UserLocationResponse.java
@@ -1,0 +1,16 @@
+package com.team4ever.backend.domain.popups.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserLocationResponse {
+	private Double latitude;
+	private Double longitude;
+	private String address;
+
+	@JsonProperty("nearby_popups")
+	private java.util.List<NearbyPopupResponse> nearbyPopups;
+}

--- a/src/main/java/com/team4ever/backend/domain/popups/repository/PopupRepository.java
+++ b/src/main/java/com/team4ever/backend/domain/popups/repository/PopupRepository.java
@@ -2,9 +2,30 @@ package com.team4ever.backend.domain.popups.repository;
 
 import com.team4ever.backend.domain.popups.entity.Popup;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface PopupRepository extends JpaRepository<Popup, Integer> {
-    // 기본 CRUD 메서드는 JpaRepository에서 제공
+
+	/**
+	 * 지정된 경계 내의 팝업스토어 조회 (위도, 경도 범위)
+	 */
+	@Query("""
+        SELECT p FROM Popup p 
+        WHERE p.latitude BETWEEN :minLat AND :maxLat 
+        AND p.longitude BETWEEN :minLng AND :maxLng
+        AND p.latitude IS NOT NULL 
+        AND p.longitude IS NOT NULL
+        ORDER BY p.id
+    """)
+	List<Popup> findPopupsInBoundingBox(
+			@Param("minLat") double minLat,
+			@Param("maxLat") double maxLat,
+			@Param("minLng") double minLng,
+			@Param("maxLng") double maxLng
+	);
 }

--- a/src/main/java/com/team4ever/backend/domain/popups/service/GeolocationService.java
+++ b/src/main/java/com/team4ever/backend/domain/popups/service/GeolocationService.java
@@ -1,0 +1,142 @@
+package com.team4ever.backend.domain.popups.service;
+
+import com.team4ever.backend.domain.popups.dto.GeolocationResponse;
+import com.team4ever.backend.global.config.NaverApiConfig;
+import com.team4ever.backend.global.exception.CustomException;
+import com.team4ever.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GeolocationService {
+
+	private final NaverApiConfig naverApiConfig;
+	private final RestTemplate restTemplate;
+
+	/**
+	 * IP 주소로 위치 정보 조회
+	 */
+	public GeolocationResponse getLocationByIp(String clientIp) {
+		try {
+			// 로컬 IP 처리
+			if (isLocalIp(clientIp)) {
+				log.warn("로컬 IP 감지: {}. 기본 위치 사용", clientIp);
+				return createDefaultLocation();
+			}
+
+			log.info("IP 기반 위치 조회 시작 - IP: {}", clientIp);
+
+			String timestamp = String.valueOf(System.currentTimeMillis());
+			String method = "GET";
+			String uri = "/geolocation/v2/geoLocation";
+			String queryString = "ip=" + clientIp + "&ext=t&responseFormatType=json"; // ext=t로 좌표 포함
+
+			// 네이버 클라우드 API 서명 생성
+			String signature = makeSignature(method, uri, timestamp, queryString);
+
+			// 헤더 설정
+			HttpHeaders headers = new HttpHeaders();
+			headers.set("x-ncp-apigw-timestamp", timestamp);
+			headers.set("x-ncp-iam-access-key", naverApiConfig.getAccessKey());
+			headers.set("x-ncp-apigw-signature-v2", signature);
+			headers.setContentType(MediaType.APPLICATION_JSON);
+
+			// API 호출
+			String url = naverApiConfig.getGeolocationUrl() + "?" + queryString;
+			HttpEntity<String> entity = new HttpEntity<>(headers);
+
+			ResponseEntity<GeolocationResponse> response = restTemplate.exchange(
+					url, HttpMethod.GET, entity, GeolocationResponse.class);
+
+			GeolocationResponse result = response.getBody();
+
+			if (result != null && "0".equals(result.getReturnCode())) {
+				GeolocationResponse.GeoLocationData location = result.getGeoLocation();
+				log.info("위치 조회 성공 - lat: {}, lng: {}, address: {}-{}-{}",
+						location.getLat(), location.getLongitude(),
+						location.getR1(), location.getR2(), location.getR3());
+				return result;
+			} else {
+				log.warn("위치 조회 실패 - returnCode: {}", result != null ? result.getReturnCode() : "null");
+				return createDefaultLocation();
+			}
+
+		} catch (Exception e) {
+			log.error("IP 기반 위치 조회 중 오류 발생", e);
+			return createDefaultLocation();
+		}
+	}
+
+	/**
+	 * 로컬 IP 판별
+	 */
+	private boolean isLocalIp(String ip) {
+		return ip == null ||
+				"127.0.0.1".equals(ip) ||
+				"0:0:0:0:0:0:0:1".equals(ip) ||
+				"localhost".equals(ip) ||
+				ip.startsWith("192.168.") ||
+				ip.startsWith("10.") ||
+				ip.startsWith("172.");
+	}
+
+	/**
+	 * 기본 위치 생성 (선릉 멀티캠퍼스 유레카 위치로 설정)
+	 */
+	private GeolocationResponse createDefaultLocation() {
+		GeolocationResponse response = new GeolocationResponse();
+		response.setReturnCode("0");
+
+		GeolocationResponse.GeoLocationData location = new GeolocationResponse.GeoLocationData();
+		location.setLat(37.503298369423);
+		location.setLongitude(127.04979962846);
+		location.setR1("서울특별시");
+		location.setR2("강남구");
+		location.setR3("선릉로428");
+
+		response.setGeoLocation(location);
+
+		return response;
+	}
+
+
+	/**
+	 * 네이버 클라우드 API 서명 생성
+	 */
+	private String makeSignature(String method, String uri, String timestamp, String queryString) {
+		try {
+			String space = " ";
+			String newLine = "\n";
+
+			String message = method +
+					space +
+					uri +
+					(queryString != null ? "?" + queryString : "") +
+					newLine +
+					timestamp +
+					newLine +
+					naverApiConfig.getAccessKey();
+
+			SecretKeySpec signingKey = new SecretKeySpec(
+					naverApiConfig.getSecretKey().getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+			Mac mac = Mac.getInstance("HmacSHA256");
+			mac.init(signingKey);
+
+			byte[] rawHmac = mac.doFinal(message.getBytes(StandardCharsets.UTF_8));
+			return Base64.getEncoder().encodeToString(rawHmac);
+
+		} catch (Exception e) {
+			throw new RuntimeException("서명 생성 실패", e);
+		}
+	}
+}

--- a/src/main/java/com/team4ever/backend/domain/popups/service/PopupService.java
+++ b/src/main/java/com/team4ever/backend/domain/popups/service/PopupService.java
@@ -1,17 +1,22 @@
 package com.team4ever.backend.domain.popups.service;
 
 import com.team4ever.backend.domain.popups.dto.PopupResponse;
+import com.team4ever.backend.domain.popups.dto.NearbyPopupsRequest;
+import com.team4ever.backend.domain.popups.dto.NearbyPopupResponse;
 import com.team4ever.backend.domain.popups.entity.Popup;
 import com.team4ever.backend.domain.popups.repository.PopupRepository;
 import com.team4ever.backend.global.exception.CustomException;
 import com.team4ever.backend.global.exception.ErrorCode;
+import com.team4ever.backend.global.util.GeoUtils;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -38,22 +43,75 @@ public class PopupService {
     }
 
     /**
+     * 근처 팝업스토어 조회
+     */
+    public List<NearbyPopupResponse> getNearbyPopups(NearbyPopupsRequest request) {
+        try {
+            log.info("근처 팝업스토어 조회 시작 - lat: {}, lng: {}, radius: {}km",
+                    request.getLat(), request.getLng(), request.getRadius());
+
+            // 검색 범위의 경계 좌표 계산
+            double[] boundingBox = GeoUtils.getBoundingBox(
+                    request.getLat(), request.getLng(), request.getRadius());
+
+            log.debug("검색 경계 - minLat: {}, maxLat: {}, minLng: {}, maxLng: {}",
+                    boundingBox[0], boundingBox[1], boundingBox[2], boundingBox[3]);
+
+            // 경계 내의 팝업스토어 조회
+            List<Popup> nearbyPopups = popupRepository.findPopupsInBoundingBox(
+                    boundingBox[0], boundingBox[1], boundingBox[2], boundingBox[3]);
+
+            // 정확한 거리 계산 및 필터링
+            List<NearbyPopupResponse> results = nearbyPopups.stream()
+                    .map(popup -> {
+                        double distance = GeoUtils.calculateDistance(
+                                request.getLat(), request.getLng(),
+                                popup.getLatitude(), popup.getLongitude());
+
+                        return NearbyPopupResponse.builder()
+                                .id(popup.getId())
+                                .name(popup.getName())
+                                .description(cleanDescription(popup.getDescription()))
+                                .address(popup.getAddress())
+                                .latitude(popup.getLatitude())
+                                .longitude(popup.getLongitude())
+                                .imageUrl(popup.getImageUrl())
+                                .distanceKm(Math.round(distance * 100.0) / 100.0) // 소수점 2자리
+                                .build();
+                    })
+                    .filter(popup -> popup.getDistanceKm() <= request.getRadius()) // 정확한 거리로 필터링
+                    .sorted((p1, p2) -> Double.compare(p1.getDistanceKm(), p2.getDistanceKm())) // 거리순 정렬
+                    .collect(Collectors.toList());
+
+            log.info("근처 팝업스토어 조회 완료 - 검색된 수: {}", results.size());
+
+            return results;
+
+        } catch (Exception e) {
+            log.error("근처 팝업스토어 조회 중 오류 발생", e);
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
      * Popup 엔티티를 PopupResponse DTO로 변환
      */
     private PopupResponse toResponse(Popup popup) {
-        // description의 \n을 공백으로 치환
-        String cleanedDescription = popup.getDescription() != null
-                ? popup.getDescription().replace("\n", " ")
-                : "";
-
         return PopupResponse.builder()
                 .id(popup.getId())
                 .name(popup.getName())
-                .description(cleanedDescription)
+                .description(cleanDescription(popup.getDescription()))
                 .address(popup.getAddress())
                 .latitude(popup.getLatitude())
                 .longitude(popup.getLongitude())
                 .imageUrl(popup.getImageUrl())
                 .build();
+    }
+
+    /**
+     * 설명 텍스트 정리 (개행문자 제거)
+     */
+    private String cleanDescription(String description) {
+        return description != null ? description.replace("\n", " ") : "";
     }
 }

--- a/src/main/java/com/team4ever/backend/global/config/NaverApiConfig.java
+++ b/src/main/java/com/team4ever/backend/global/config/NaverApiConfig.java
@@ -1,0 +1,16 @@
+package com.team4ever.backend.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "naver.cloud")
+@Getter
+@Setter
+public class NaverApiConfig {
+	private String accessKey;
+	private String secretKey;
+	private String geolocationUrl = "https://geolocation.apigw.ntruss.com/geolocation/v2/geoLocation";
+}

--- a/src/main/java/com/team4ever/backend/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/team4ever/backend/global/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.team4ever.backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+	@Bean
+	public RestTemplate restTemplate() {
+		return new RestTemplate();
+	}
+}

--- a/src/main/java/com/team4ever/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/team4ever/backend/global/exception/ErrorCode.java
@@ -35,9 +35,14 @@ public enum ErrorCode {
 	COUPON_NOT_CLAIMED(HttpStatus.NOT_FOUND, "발급된 쿠폰이 없습니다."),
 	COUPON_ALREADY_USED(HttpStatus.CONFLICT, "이미 사용된 쿠폰입니다."),
 
+	// 위치 기반 API 에러
+	GEOLOCATION_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "위치 정보 조회 중 오류가 발생했습니다."),
+
 	// 팝업스토어 전용 에러
 	POPUP_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 ID의 팝업스토어가 없습니다."),
 	POPUP_ACCESS_DENIED(HttpStatus.FORBIDDEN, "팝업스토어 조회 권한이 없습니다.");
+
+
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/team4ever/backend/global/util/GeoUtils.java
+++ b/src/main/java/com/team4ever/backend/global/util/GeoUtils.java
@@ -1,0 +1,46 @@
+package com.team4ever.backend.global.util;
+
+public class GeoUtils {
+
+	private static final double EARTH_RADIUS_KM = 6371.0;
+
+	/**
+	 * 두 지점 간의 거리 계산 (Haversine formula)
+	 * @param lat1 첫 번째 지점의 위도
+	 * @param lng1 첫 번째 지점의 경도
+	 * @param lat2 두 번째 지점의 위도
+	 * @param lng2 두 번째 지점의 경도
+	 * @return 거리 (km)
+	 */
+	public static double calculateDistance(double lat1, double lng1, double lat2, double lng2) {
+		double latDistance = Math.toRadians(lat2 - lat1);
+		double lngDistance = Math.toRadians(lng2 - lng1);
+
+		double a = Math.sin(latDistance / 2) * Math.sin(latDistance / 2) +
+				Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2)) *
+						Math.sin(lngDistance / 2) * Math.sin(lngDistance / 2);
+
+		double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+		return EARTH_RADIUS_KM * c;
+	}
+
+	/**
+	 * 지정된 반경 내의 경계 좌표 계산
+	 * @param centerLat 중심점 위도
+	 * @param centerLng 중심점 경도
+	 * @param radiusKm 반경 (km)
+	 * @return [minLat, maxLat, minLng, maxLng]
+	 */
+	public static double[] getBoundingBox(double centerLat, double centerLng, double radiusKm) {
+		double latOffset = radiusKm / 111.0; // 1도당 약 111km
+		double lngOffset = radiusKm / (111.0 * Math.cos(Math.toRadians(centerLat)));
+
+		return new double[] {
+				centerLat - latOffset,  // minLat
+				centerLat + latOffset,  // maxLat
+				centerLng - lngOffset,  // minLng
+				centerLng + lngOffset   // maxLng
+		};
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -106,7 +106,6 @@ springdoc:
     tagsSorter: alpha
     display-request-duration: true
 
-
 fastapi:
   chat:
     host: ${FASTAPI_HOST:localhost}
@@ -120,3 +119,7 @@ fastapi:
       question: /api/ubti/question
       result:   /api/ubti/result
 
+naver:
+  cloud:
+    access-key: ${NAVER_CLOUD_ACCESS_KEY}
+    secret-key: ${NAVER_CLOUD_SECRET_KEY}


### PR DESCRIPTION
### #️⃣연관된 이슈
<!-- PR과 연관된 이슈 번호를 작성해주세요. -->
> close: #88 

### 🔎 작업 내용
- [x] **GET** `/api/popups/nearby` 수동 좌표 기반 근처 팝업스토어 조회 API 구현
  - 위도/경도 파라미터 기준 근처 팝업스토어 검색
  - Haversine 공식을 사용한 거리 계산
  - 거리순 자동 정렬 및 반경 내 필터링
- [x] **GET** `/api/popups/nearby/auto` IP 기반 자동 위치 근처 팝업스토어 조회 API 구현
  - 네이버 클라우드 Geolocation API를 통한 IP 기반 위치 추정
  - 사용자 위치 정보와 근처 팝업스토어를 통합 응답
  - 로컬 IP 감지 시 선릉 멀캠으로 기본 위치 설정

> 두 API 모두 radius는 옵셔널이므로 입력하지 않으면 기본 5로 지정됩니다.

### **구현 로직 상세**
**거리 캐싱**: 계산된 거리를 DTO에 포함하여 중복 계산 방지
**스트림 파이프라인**: 필터링과 정렬을 한 번에 처리
- **API 실패 시 폴백**: 네이버 API 오류 시 기본 위치인 멀캠으로 대체
- **클라이언트 IP 추출**: 프록시 환경 고려한 다단계 IP 추출 로직 설정


### 📸 스크린샷
> 위도 경도 프론트엔드에서 받아온다면 이 API 사용

![스크린샷 2025-06-12 오후 5 09 42](https://github.com/user-attachments/assets/5a9d1b3e-cd93-4078-8802-2e142ee54706)

> 자동으로 IP 감지 및 네이버 API 사용한 위치 조회

![스크린샷 2025-06-12 오후 5 11 07](https://github.com/user-attachments/assets/dcb53bc9-5f37-4fbf-b45a-5ae468cd5b56)

### :loudspeaker: 전달사항


#### 🔧 **추가된 의존성**
- **RestTemplate**: 네이버 클라우드 API 호출용 HTTP 클라이언트
- **javax.crypto**: HMAC-SHA256 서명 생성용 암호화 라이브러리 (기본 JDK 포함)

#### 🌍 **네이버 클라우드 Geolocation API 설정 추가해서 `.env`가 수정되었으니 노션에서 확인바랍니다!**
```yaml
# application.yml
naver:
  cloud:
    access-key: ${NAVER_CLOUD_ACCESS_KEY}
    secret-key: ${NAVER_CLOUD_SECRET_KEY}
```

> **정확도 우선**: 프론트엔드 GPS → `/nearby` API 사용 권장
**편의성 우선**: 사용자 동의 없이 → `/nearby/auto` API 사용


- 추가한 라이브러리나 특이 사항

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
