### PR TITLE
Feat: [EVER-143] 사용자 보유 쿠폰 조회 API 구현

### DIFF
--- a/src/main/java/com/team4ever/backend/domain/coupon/repository/UserCouponRepository.java
+++ b/src/main/java/com/team4ever/backend/domain/coupon/repository/UserCouponRepository.java
@@ -15,6 +15,6 @@ public interface UserCouponRepository extends JpaRepository<UserCoupon, Integer>
     boolean existsByUserIdAndCouponId(Long userId, Integer couponId);
 
     // 사용자별 전체 쿠폰 조회 (isUsed 상태 확인)
-    @EntityGraph(attributePaths = "coupon")
+    @EntityGraph(attributePaths = {"coupon", "coupon.brand"})
     List<UserCoupon> findByUserId(Long userId);
 }

--- a/src/main/java/com/team4ever/backend/domain/user/Controller/UserController.java
+++ b/src/main/java/com/team4ever/backend/domain/user/Controller/UserController.java
@@ -14,6 +14,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
+import com.team4ever.backend.domain.user.dto.UserCouponListResponse;
+
 
 @RestController
 @RequestMapping("/api/user")
@@ -73,4 +75,20 @@ public class UserController {
         LikedCouponsResponse response = svc.getLikedCoupons(oauthUserId);
         return ResponseEntity.ok(BaseResponse.success(response));
     }
+    //보유중인 쿠폰 조회
+    @GetMapping("/coupons")
+    public ResponseEntity<BaseResponse<UserCouponListResponse>> getMyCoupons(@AuthenticationPrincipal OAuth2User oAuth2User) {
+        if (oAuth2User == null || oAuth2User.getAttribute("id") == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        String oauthUserId = oAuth2User.getAttribute("id").toString();
+        UserCouponListResponse response = svc.getMyCoupons(oauthUserId);
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+
+
+
+
 }

--- a/src/main/java/com/team4ever/backend/domain/user/Service/UserService.java
+++ b/src/main/java/com/team4ever/backend/domain/user/Service/UserService.java
@@ -4,10 +4,14 @@ import com.team4ever.backend.domain.user.dto.CreateUserRequest;
 import com.team4ever.backend.domain.user.dto.LikedCouponsResponse;
 import com.team4ever.backend.domain.user.dto.UserResponse;
 import com.team4ever.backend.domain.user.dto.UserSubscriptionListResponse;
+import com.team4ever.backend.domain.user.dto.UserCouponListResponse;
+
 
 public interface UserService {
 	Long createUser(CreateUserRequest req);
 	UserResponse getUserByUserId(String userId);
 	UserSubscriptionListResponse getUserSubscriptions(String oauthUserId);
     LikedCouponsResponse getLikedCoupons(String oauthUserId);
+	UserCouponListResponse getMyCoupons(String oauthUserId);
+
 }

--- a/src/main/java/com/team4ever/backend/domain/user/dto/CouponInfoResponse.java
+++ b/src/main/java/com/team4ever/backend/domain/user/dto/CouponInfoResponse.java
@@ -1,0 +1,10 @@
+package com.team4ever.backend.domain.user.dto;
+
+public record CouponInfoResponse(
+    Long couponId,
+    String title,
+    BrandInfo brand,
+    boolean isUsed
+) {
+    public record BrandInfo(Long id, String name, String imageUrl) {}
+}

--- a/src/main/java/com/team4ever/backend/domain/user/dto/UserCouponListResponse.java
+++ b/src/main/java/com/team4ever/backend/domain/user/dto/UserCouponListResponse.java
@@ -1,0 +1,9 @@
+package com.team4ever.backend.domain.user.dto;
+
+import java.util.List;
+import com.team4ever.backend.domain.user.dto.CouponInfoResponse;
+
+
+public record UserCouponListResponse(
+        List<CouponInfoResponse> coupons
+) {}

--- a/src/main/java/com/team4ever/backend/global/config/WebMvcConfig.java
+++ b/src/main/java/com/team4ever/backend/global/config/WebMvcConfig.java
@@ -57,6 +57,8 @@ public class WebMvcConfig implements WebMvcConfigurer {
                         "/api/popups/**",
                         "/api/coupons",
                         "/api/chat",
+                        "/api/coupons/**",
+                        "/api/user/coupons",
                         //Swagger
                         "/swagger-ui/**",
                         "/swagger-ui.html",


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #90 

### 🔎 작업 내용

- `user_coupons.user_id`에 잘못된 값(`users.user_id`)이 저장되어 보유 쿠폰이 조회되지 않던 문제 수정
- `user_coupons.user_id` → `users.id(PK)`로 정정
- 외래키 설정을 위해 `BIGINT`로 타입 통일
- Hibernate 쿼리 정상 수행 확인 및 응답 결과 비어 있던 문제 해결

### 📸 스크린샷
<img width="770" alt="image" src="https://github.com/user-attachments/assets/b45fefe1-4020-47b0-b628-6b2fa3db3df9" />

### :loudspeaker: 전달사항

- Swagger를 통해 `/api/user/coupons` 호출 시 정상 응답 확인

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
