### PR TITLE
Feat: [EVER-147] API 사용자 및 인증 관련 Swagger 한글 summary 추가

### DIFF
--- a/src/main/java/com/team4ever/backend/domain/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/team4ever/backend/domain/attendance/controller/AttendanceController.java
@@ -21,13 +21,13 @@ public class AttendanceController {
         return BaseResponse.success(attendanceService.checkToday(req.getUserId()));
     }
 
-    @Operation(summary = "연속 출석 일수 조회")
+    @Operation(summary = "내 연속 출석 일수 조회")
     @GetMapping("/streak")
     public BaseResponse<Integer> getStreak(@RequestParam Long userId) {
         return BaseResponse.success(attendanceService.getStreak(userId));
     }
 
-    @Operation(summary = "연속 출석률 조회")
+    @Operation(summary = "내 연속 출석률 조회")
     @GetMapping("/rate")
     public BaseResponse<Double> getRate(@RequestParam Long userId) {
         double rate = attendanceService.calculateStreak(userId);

--- a/src/main/java/com/team4ever/backend/domain/benefit/controller/BenefitController.java
+++ b/src/main/java/com/team4ever/backend/domain/benefit/controller/BenefitController.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import java.time.LocalDate;
 import java.util.List;
+import io.swagger.v3.oas.annotations.Operation;
+
 import com.team4ever.backend.domain.benefit.dto.BenefitApiResponse;
 
 @RestController

--- a/src/main/java/com/team4ever/backend/domain/benefit/controller/BenefitController.java
+++ b/src/main/java/com/team4ever/backend/domain/benefit/controller/BenefitController.java
@@ -18,11 +18,13 @@ public class BenefitController {
 
     private final BenefitService benefitService;
 
+    @Operation(summary = "이번 달 전체 혜택 조회")
     @GetMapping
     public BenefitApiResponse<List<BenefitResponse>> getAllBenefits() {
         return BenefitApiResponse.ok("요청이 성공적으로 처리되었습니다.", benefitService.getAllBenefits());
     }
 
+    @Operation(summary = "특정 날짜 혜택 조회")
     @GetMapping(params = "date")
     public BenefitApiResponse<List<BenefitResponse>> getBenefitsByDate(@RequestParam String date) {
         LocalDate parsedDate = LocalDate.parse(date);

--- a/src/main/java/com/team4ever/backend/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/team4ever/backend/domain/chat/controller/ChatController.java
@@ -20,6 +20,7 @@ public class ChatController {
 
 	private final ChatService chatService;
 
+	@Operation(summary = "요금제 및 구독 서비스 추천")
 	@PostMapping(
 			consumes = MediaType.APPLICATION_JSON_VALUE,
 			produces = MediaType.TEXT_EVENT_STREAM_VALUE // 스트리밍용 Content-Type
@@ -28,6 +29,7 @@ public class ChatController {
 		return chatService.getChatResponse(req);
 	}
 
+	@Operation(summary = "좋아요한 쿠폰 기반 구독 서비스 추천")
 	@PostMapping(
 			value = "/likes",
 			consumes = MediaType.APPLICATION_JSON_VALUE,

--- a/src/main/java/com/team4ever/backend/domain/common/couponlike/CouponLike.java
+++ b/src/main/java/com/team4ever/backend/domain/common/couponlike/CouponLike.java
@@ -27,6 +27,7 @@ public class CouponLike {
 	@Column(name = "brand_id", nullable = false)
 	private Integer brandId;
 
+	@Builder.Default
 	@Column(name = "is_liked", nullable = false)
 	private Boolean isLiked = false;
 }

--- a/src/main/java/com/team4ever/backend/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/team4ever/backend/domain/plan/controller/PlanController.java
@@ -7,6 +7,7 @@ import com.team4ever.backend.domain.plan.service.PlanService;
 import com.team4ever.backend.global.exception.CustomException;
 import com.team4ever.backend.global.exception.ErrorCode;
 import com.team4ever.backend.global.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -22,9 +23,7 @@ public class PlanController {
 
 	private final PlanService planService;
 
-	/**
-	 * 내가 사용중인 요금제 조회
-	 */
+	@Operation(summary = "내가 사용중인 요금제 조회")
 	@GetMapping
 	public ResponseEntity<BaseResponse<PlanResponse>> getCurrentPlan(
 			@AuthenticationPrincipal OAuth2User oAuth2User
@@ -38,9 +37,8 @@ public class PlanController {
 
 		return ResponseEntity.ok(BaseResponse.success(response));
 	}
-	/**
-	 * 요금제 변경
-	 */
+
+	@Operation(summary = "요금제 변경")
 	@PostMapping
 	public ResponseEntity<BaseResponse<PlanChangeResponse>> changePlan(
 			@Valid @RequestBody PlanChangeRequest request,
@@ -56,9 +54,7 @@ public class PlanController {
 		return ResponseEntity.ok(BaseResponse.success(response));
 	}
 
-	/**
-	 * 요금제 해지
-	 */
+	@Operation(summary = "요금제 해지")
 	@DeleteMapping
 	public ResponseEntity<BaseResponse<PlanChangeResponse>> cancelPlan(
 			@AuthenticationPrincipal OAuth2User oAuth2User

--- a/src/main/java/com/team4ever/backend/domain/popups/controller/PopupController.java
+++ b/src/main/java/com/team4ever/backend/domain/popups/controller/PopupController.java
@@ -3,6 +3,7 @@ package com.team4ever.backend.domain.popups.controller;
 import com.team4ever.backend.domain.popups.dto.PopupResponse;
 import com.team4ever.backend.domain.popups.service.PopupService;
 import com.team4ever.backend.global.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,18 +17,14 @@ public class PopupController {
 
     private final PopupService popupService;
 
-    /**
-     * 팝업스토어 전체 조회
-     */
+    @Operation(summary = "팝업스토어 전체 조회")
     @GetMapping
     public ResponseEntity<BaseResponse<List<PopupResponse>>> getAllPopups() {
         List<PopupResponse> result = popupService.getAllPopups();
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 
-    /**
-     * 팝업스토어 ID로 조회
-     */
+    @Operation(summary = "특정 팝업스토어 조회")
     @GetMapping("/{id}")
     public ResponseEntity<BaseResponse<PopupResponse>> getPopupById(@PathVariable Integer id) {
         PopupResponse result = popupService.getPopupById(id);

--- a/src/main/java/com/team4ever/backend/domain/subscriptions/controller/SubscriptionController.java
+++ b/src/main/java/com/team4ever/backend/domain/subscriptions/controller/SubscriptionController.java
@@ -5,6 +5,7 @@ import com.team4ever.backend.domain.subscriptions.service.SubscriptionService;
 import com.team4ever.backend.global.exception.CustomException;
 import com.team4ever.backend.global.exception.ErrorCode;
 import com.team4ever.backend.global.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -23,9 +24,7 @@ public class SubscriptionController {
 
 	private final SubscriptionService subscriptionService;
 
-	/**
-	 * 메인 구독 상품 조회
-	 */
+	@Operation(summary = "메인 구독 상품 전체 조회")
 	@GetMapping("/main")
 	public ResponseEntity<BaseResponse<List<SubscriptionResponse>>> getMainSubscriptions() {
 		return ResponseEntity.ok(success(
@@ -33,9 +32,7 @@ public class SubscriptionController {
 		));
 	}
 
-	/**
-	 * 라이프 구독 브랜드 조회 (전체 or 카테고리별)
-	 */
+	@Operation(summary = "라이프 구독 브랜드 조회 (전체 or 카테고리별)")
 	@GetMapping("/brands")
 	public ResponseEntity<BaseResponse<List<BrandResponse>>> getLifeSubscriptionBrands(
 			@RequestParam(required = false) String category) {
@@ -51,9 +48,7 @@ public class SubscriptionController {
 	}
 
 
-	/**
-	 * 구독 가입
-	 */
+	@Operation(summary = "구독 상품 가입")
 	@PostMapping("/subscribe")
 	public ResponseEntity<BaseResponse<SubscribeResponse>> subscribe(
 			@RequestBody SubscribeRequest request,
@@ -71,9 +66,7 @@ public class SubscriptionController {
 	}
 
 
-	/**
-	 * 구독 해지
-	 */
+	@Operation(summary = "구독 상품 해지")
 	@DeleteMapping("/unsubscribe")
 	public ResponseEntity<BaseResponse<UnsubscribeResponse>> unsubscribe(
 			@RequestBody UnsubscribeRequest request,

--- a/src/main/java/com/team4ever/backend/domain/ubti/controller/UBTIController.java
+++ b/src/main/java/com/team4ever/backend/domain/ubti/controller/UBTIController.java
@@ -5,6 +5,7 @@ import com.team4ever.backend.domain.ubti.dto.UBTIResult;
 import com.team4ever.backend.domain.ubti.service.UBTIService;
 import com.team4ever.backend.global.response.BaseResponse;
 import com.team4ever.backend.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.codec.ServerSentEvent;
@@ -19,6 +20,7 @@ public class UBTIController {
 
 	private final UBTIService ubtiService;
 
+	@Operation(summary = "통신유형 검사")
 	@PostMapping(
 			value = "/question",
 			consumes = MediaType.APPLICATION_JSON_VALUE,
@@ -28,6 +30,7 @@ public class UBTIController {
 		return ubtiService.nextQuestionStream(req);
 	}
 
+	@Operation(summary = "해당 세션의 검사결과 조회")
 	@PostMapping("/result")
 	public Mono<BaseResponse<UBTIResult>> finalResult(@RequestBody UBTIRequest req) {
 		return ubtiService.finalResultWrapped(req);

--- a/src/main/java/com/team4ever/backend/domain/user/Controller/UserController.java
+++ b/src/main/java/com/team4ever/backend/domain/user/Controller/UserController.java
@@ -9,6 +9,7 @@ import com.team4ever.backend.global.exception.CustomException;
 import com.team4ever.backend.global.exception.ErrorCode;
 import com.team4ever.backend.global.response.BaseResponse;
 import com.team4ever.backend.global.security.JwtTokenProvider;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -27,6 +28,7 @@ public class UserController {
     private final UserService svc;
     private final JwtTokenProvider jwtProvider;
 
+    @Operation(summary = "새 회원 만들기")
     // 신규 회원 생성
     @PostMapping
     public ResponseEntity<Long> createUser(
@@ -36,15 +38,15 @@ public class UserController {
         return ResponseEntity.ok(id);
     }
 
+    @Operation(summary = "내 정보 조회")
     // userId로 회원 정보 조회
     @GetMapping
     public ResponseEntity<UserResponse> getCurrentUser() {
         UserResponse dto = svc.getCurrentUser();
         return ResponseEntity.ok(dto);
     }
-    /**
-     * 내 구독 상품 목록 조회
-     */
+
+    @Operation(summary = "내 구독 상품 목록 조회")
     @GetMapping("/subscriptions")
     public ResponseEntity<BaseResponse<UserSubscriptionListResponse>> getUserSubscriptions(
             @AuthenticationPrincipal OAuth2User oAuth2User
@@ -59,9 +61,7 @@ public class UserController {
         return ResponseEntity.ok(BaseResponse.success(response));
     }
 
-    /**
-     * 좋아요한 쿠폰 목록 조회
-     */
+    @Operation(summary = "내 좋아요한 쿠폰 목록 조회")
     @GetMapping("/likes/coupons")
     public ResponseEntity<BaseResponse<LikedCouponsResponse>> getLikedCoupons(
             @AuthenticationPrincipal OAuth2User oAuth2User

--- a/src/main/java/com/team4ever/backend/global/controller/JwtTokenController.java
+++ b/src/main/java/com/team4ever/backend/global/controller/JwtTokenController.java
@@ -1,6 +1,7 @@
 package com.team4ever.backend.global.controller;
 
 import com.team4ever.backend.global.security.*;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.*;
@@ -21,11 +22,13 @@ public class JwtTokenController {
         this.redisService = redisService;
     }
 
+    @Operation(summary = "로그인")
     @GetMapping("/auth/{provider}")
     public void login(@PathVariable String provider, HttpServletResponse response) throws IOException {
         response.sendRedirect("/oauth2/authorization/" + provider);
     }
 
+    @Operation(summary = "로그아웃")
     @PostMapping("/logout")
     public ResponseEntity<?> logout(@RequestParam String userId,
                                     HttpServletResponse response) {
@@ -45,6 +48,7 @@ public class JwtTokenController {
         return ResponseEntity.ok().body("Logged out");
     }
 
+    @Operation(summary = "토큰 재발급")
     @PostMapping("/refresh")
     public ResponseEntity<Void> refresh(@RequestParam String userId,
                                         HttpServletResponse response) {


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #94 

### 🔎 작업 내용

- [x] 27개 API Swagger 한글 summary 추가
- [x] Swagger 문서 가독성 향상 및 Swagger UI에서 API 문서 검색 및 분류 용이
- [x] API 기능별 목적을 명확히 나타낼 수 있도록 모든 컨트롤러에 @Operation(summary = "...") 일관 적용
- 모든 Swagger 애너테이션은 OpenAPI 3.x (io.swagger.v3.oas.annotations.*) 기준으로 적용
- 기존 엔드포인트 로직은 변경 없이 문서화 목적에 한정된 변경 사항

### 📸 스크린샷
![image](https://github.com/user-attachments/assets/f5b094d5-6748-4fb8-ada3-86d52ce43e89)
![image](https://github.com/user-attachments/assets/006a3a45-9512-4e21-87c0-398d59f3f42a)

### :loudspeaker: 전달사항
@abyss-s @kny0ng125 @eunchrri @illustermin 
앞으로 PR 올릴 API에 한글 summary 같이 적어서 올려주세용~😊

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
