### PR TITLE
Feat: [EVER-139] 전체 요금제 및 상세 요금제 조회 API 만들기, 요금제 관련 Swagger 정리

### DIFF
--- a/src/main/java/com/team4ever/backend/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/team4ever/backend/domain/plan/controller/PlanController.java
@@ -1,70 +1,37 @@
 package com.team4ever.backend.domain.plan.controller;
 
-import com.team4ever.backend.domain.plan.dto.PlanChangeRequest;
-import com.team4ever.backend.domain.plan.dto.PlanChangeResponse;
 import com.team4ever.backend.domain.plan.dto.PlanResponse;
 import com.team4ever.backend.domain.plan.service.PlanService;
-import com.team4ever.backend.global.exception.CustomException;
-import com.team4ever.backend.global.exception.ErrorCode;
 import com.team4ever.backend.global.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
 
-import jakarta.validation.Valid;
+import java.util.List;
 
 @RestController
-@RequestMapping("/api/user/plans")
+@RequestMapping("/api/plans")
 @RequiredArgsConstructor
+@Tag(name = "요금제 API", description = "요금제 조회 관련 API")
 public class PlanController {
 
 	private final PlanService planService;
 
-	@Operation(summary = "내가 사용중인 요금제 조회")
+	@Operation(summary = "전체 요금제 조회")
 	@GetMapping
-	public ResponseEntity<BaseResponse<PlanResponse>> getCurrentPlan(
-			@AuthenticationPrincipal OAuth2User oAuth2User
-	) {
-		if (oAuth2User == null || oAuth2User.getAttribute("id") == null) {
-			throw new CustomException(ErrorCode.UNAUTHORIZED);
-		}
-
-		String oauthUserId = oAuth2User.getAttribute("id").toString();
-		PlanResponse response = planService.getCurrentPlan(oauthUserId);
-
+	public ResponseEntity<BaseResponse<List<PlanResponse>>> getAllPlans() {
+		List<PlanResponse> response = planService.getAllPlans();
 		return ResponseEntity.ok(BaseResponse.success(response));
 	}
 
-	@Operation(summary = "요금제 변경")
-	@PostMapping
-	public ResponseEntity<BaseResponse<PlanChangeResponse>> changePlan(
-			@Valid @RequestBody PlanChangeRequest request,
-			@AuthenticationPrincipal OAuth2User oAuth2User
+	@Operation(summary = "요금제 상세 조회")
+	@GetMapping("/{planId}")
+	public ResponseEntity<BaseResponse<PlanResponse>> getPlanDetail(
+			@PathVariable Integer planId
 	) {
-		if (oAuth2User == null || oAuth2User.getAttribute("id") == null) {
-			throw new CustomException(ErrorCode.UNAUTHORIZED);
-		}
-
-		String oauthUserId = oAuth2User.getAttribute("id").toString();
-		PlanChangeResponse response = planService.changePlan(request, oauthUserId);
-
-		return ResponseEntity.ok(BaseResponse.success(response));
-	}
-
-	@Operation(summary = "요금제 해지")
-	@DeleteMapping
-	public ResponseEntity<BaseResponse<PlanChangeResponse>> cancelPlan(
-			@AuthenticationPrincipal OAuth2User oAuth2User
-	) {
-		if (oAuth2User == null || oAuth2User.getAttribute("id") == null) {
-			throw new CustomException(ErrorCode.UNAUTHORIZED);
-		}
-
-		String oauthUserId = oAuth2User.getAttribute("id").toString();
-		PlanChangeResponse response = planService.cancelPlan(oauthUserId);
+		PlanResponse response = planService.getPlanDetail(planId);
 		return ResponseEntity.ok(BaseResponse.success(response));
 	}
 }

--- a/src/main/java/com/team4ever/backend/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/team4ever/backend/domain/plan/controller/PlanController.java
@@ -4,6 +4,11 @@ import com.team4ever.backend.domain.plan.dto.PlanResponse;
 import com.team4ever.backend.domain.plan.service.PlanService;
 import com.team4ever.backend.global.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,21 +19,61 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/plans")
 @RequiredArgsConstructor
-@Tag(name = "요금제 API", description = "요금제 조회 관련 API")
+@Tag(name = "요금제 API", description = "요금제 조회 관련 API (인증 불필요)")
 public class PlanController {
 
 	private final PlanService planService;
 
-	@Operation(summary = "전체 요금제 조회")
+	@Operation(
+			summary = "전체 요금제 조회",
+			description = "활성화된 모든 요금제 목록을 조회합니다."
+	)
+	@ApiResponses(value = {
+			@ApiResponse(
+					responseCode = "200",
+					description = "요금제 목록 조회 성공",
+					content = @Content(schema = @Schema(implementation = BaseResponse.class))
+			),
+			@ApiResponse(
+					responseCode = "500",
+					description = "서버 내부 오류",
+					content = @Content(schema = @Schema(implementation = BaseResponse.class))
+			)
+	})
 	@GetMapping
 	public ResponseEntity<BaseResponse<List<PlanResponse>>> getAllPlans() {
 		List<PlanResponse> response = planService.getAllPlans();
 		return ResponseEntity.ok(BaseResponse.success(response));
 	}
 
-	@Operation(summary = "요금제 상세 조회")
+	@Operation(
+			summary = "요금제 상세 조회",
+			description = "특정 요금제의 상세 정보를 조회합니다."
+	)
+	@ApiResponses(value = {
+			@ApiResponse(
+					responseCode = "200",
+					description = "요금제 상세 조회 성공",
+					content = @Content(schema = @Schema(implementation = BaseResponse.class))
+			),
+			@ApiResponse(
+					responseCode = "404",
+					description = "요금제를 찾을 수 없음",
+					content = @Content(schema = @Schema(implementation = BaseResponse.class))
+			),
+			@ApiResponse(
+					responseCode = "500",
+					description = "서버 내부 오류",
+					content = @Content(schema = @Schema(implementation = BaseResponse.class))
+			)
+	})
 	@GetMapping("/{planId}")
 	public ResponseEntity<BaseResponse<PlanResponse>> getPlanDetail(
+			@Parameter(
+					description = "조회할 요금제 ID",
+					required = true,
+					example = "1"
+			)
 			@PathVariable Integer planId
 	) {
 		PlanResponse response = planService.getPlanDetail(planId);

--- a/src/main/java/com/team4ever/backend/domain/plan/controller/UserPlanController.java
+++ b/src/main/java/com/team4ever/backend/domain/plan/controller/UserPlanController.java
@@ -8,6 +8,12 @@ import com.team4ever.backend.global.exception.CustomException;
 import com.team4ever.backend.global.exception.ErrorCode;
 import com.team4ever.backend.global.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,14 +26,41 @@ import jakarta.validation.Valid;
 @RestController
 @RequestMapping("/api/user/plans")
 @RequiredArgsConstructor
-@Tag(name = "사용자 요금제 API", description = "사용자 개인 요금제 관리 API")
+@Tag(name = "사용자 요금제 API", description = "사용자 개인 요금제 관리 API (인증 필요)")
+@SecurityRequirement(name = "bearerAuth")
 public class UserPlanController {
 
 	private final PlanService planService;
 
-	@Operation(summary = "내가 사용중인 요금제 조회")
+	@Operation(
+			summary = "내가 사용중인 요금제 조회",
+			description = "현재 로그인한 사용자가 사용중인 요금제 정보를 조회합니다."
+	)
+	@ApiResponses(value = {
+			@ApiResponse(
+					responseCode = "200",
+					description = "사용자 요금제 조회 성공",
+					content = @Content(schema = @Schema(implementation = BaseResponse.class))
+			),
+			@ApiResponse(
+					responseCode = "401",
+					description = "인증되지 않은 사용자",
+					content = @Content(schema = @Schema(implementation = BaseResponse.class))
+			),
+			@ApiResponse(
+					responseCode = "404",
+					description = "사용자 또는 요금제를 찾을 수 없음",
+					content = @Content(schema = @Schema(implementation = BaseResponse.class))
+			),
+			@ApiResponse(
+					responseCode = "500",
+					description = "서버 내부 오류",
+					content = @Content(schema = @Schema(implementation = BaseResponse.class))
+			)
+	})
 	@GetMapping
 	public ResponseEntity<BaseResponse<PlanResponse>> getCurrentPlan(
+			@Parameter(hidden = true)
 			@AuthenticationPrincipal OAuth2User oAuth2User
 	) {
 		if (oAuth2User == null || oAuth2User.getAttribute("id") == null) {
@@ -40,10 +73,45 @@ public class UserPlanController {
 		return ResponseEntity.ok(BaseResponse.success(response));
 	}
 
-	@Operation(summary = "요금제 변경")
+	@Operation(
+			summary = "요금제 변경",
+			description = "현재 로그인한 사용자의 요금제를 변경합니다."
+	)
+	@ApiResponses(value = {
+			@ApiResponse(
+					responseCode = "200",
+					description = "요금제 변경 성공",
+					content = @Content(schema = @Schema(implementation = BaseResponse.class))
+			),
+			@ApiResponse(
+					responseCode = "400",
+					description = "잘못된 요청 (이미 사용중인 요금제 등)",
+					content = @Content(schema = @Schema(implementation = BaseResponse.class))
+			),
+			@ApiResponse(
+					responseCode = "401",
+					description = "인증되지 않은 사용자",
+					content = @Content(schema = @Schema(implementation = BaseResponse.class))
+			),
+			@ApiResponse(
+					responseCode = "404",
+					description = "사용자 또는 요금제를 찾을 수 없음",
+					content = @Content(schema = @Schema(implementation = BaseResponse.class))
+			),
+			@ApiResponse(
+					responseCode = "500",
+					description = "서버 내부 오류",
+					content = @Content(schema = @Schema(implementation = BaseResponse.class))
+			)
+	})
 	@PostMapping
 	public ResponseEntity<BaseResponse<PlanChangeResponse>> changePlan(
+			@Parameter(
+					description = "요금제 변경 요청 정보",
+					required = true
+			)
 			@Valid @RequestBody PlanChangeRequest request,
+			@Parameter(hidden = true)
 			@AuthenticationPrincipal OAuth2User oAuth2User
 	) {
 		if (oAuth2User == null || oAuth2User.getAttribute("id") == null) {
@@ -56,9 +124,40 @@ public class UserPlanController {
 		return ResponseEntity.ok(BaseResponse.success(response));
 	}
 
-	@Operation(summary = "요금제 해지")
+	@Operation(
+			summary = "요금제 해지",
+			description = "현재 로그인한 사용자의 요금제를 해지합니다."
+	)
+	@ApiResponses(value = {
+			@ApiResponse(
+					responseCode = "200",
+					description = "요금제 해지 성공",
+					content = @Content(schema = @Schema(implementation = BaseResponse.class))
+			),
+			@ApiResponse(
+					responseCode = "400",
+					description = "해지할 요금제가 없음",
+					content = @Content(schema = @Schema(implementation = BaseResponse.class))
+			),
+			@ApiResponse(
+					responseCode = "401",
+					description = "인증되지 않은 사용자",
+					content = @Content(schema = @Schema(implementation = BaseResponse.class))
+			),
+			@ApiResponse(
+					responseCode = "404",
+					description = "사용자를 찾을 수 없음",
+					content = @Content(schema = @Schema(implementation = BaseResponse.class))
+			),
+			@ApiResponse(
+					responseCode = "500",
+					description = "서버 내부 오류",
+					content = @Content(schema = @Schema(implementation = BaseResponse.class))
+			)
+	})
 	@DeleteMapping
 	public ResponseEntity<BaseResponse<PlanChangeResponse>> cancelPlan(
+			@Parameter(hidden = true)
 			@AuthenticationPrincipal OAuth2User oAuth2User
 	) {
 		if (oAuth2User == null || oAuth2User.getAttribute("id") == null) {

--- a/src/main/java/com/team4ever/backend/domain/plan/controller/UserPlanController.java
+++ b/src/main/java/com/team4ever/backend/domain/plan/controller/UserPlanController.java
@@ -1,0 +1,72 @@
+package com.team4ever.backend.domain.plan.controller;
+
+import com.team4ever.backend.domain.plan.dto.PlanChangeRequest;
+import com.team4ever.backend.domain.plan.dto.PlanChangeResponse;
+import com.team4ever.backend.domain.plan.dto.PlanResponse;
+import com.team4ever.backend.domain.plan.service.PlanService;
+import com.team4ever.backend.global.exception.CustomException;
+import com.team4ever.backend.global.exception.ErrorCode;
+import com.team4ever.backend.global.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/user/plans")
+@RequiredArgsConstructor
+@Tag(name = "사용자 요금제 API", description = "사용자 개인 요금제 관리 API")
+public class UserPlanController {
+
+	private final PlanService planService;
+
+	@Operation(summary = "내가 사용중인 요금제 조회")
+	@GetMapping
+	public ResponseEntity<BaseResponse<PlanResponse>> getCurrentPlan(
+			@AuthenticationPrincipal OAuth2User oAuth2User
+	) {
+		if (oAuth2User == null || oAuth2User.getAttribute("id") == null) {
+			throw new CustomException(ErrorCode.UNAUTHORIZED);
+		}
+
+		String oauthUserId = oAuth2User.getAttribute("id").toString();
+		PlanResponse response = planService.getCurrentPlan(oauthUserId);
+
+		return ResponseEntity.ok(BaseResponse.success(response));
+	}
+
+	@Operation(summary = "요금제 변경")
+	@PostMapping
+	public ResponseEntity<BaseResponse<PlanChangeResponse>> changePlan(
+			@Valid @RequestBody PlanChangeRequest request,
+			@AuthenticationPrincipal OAuth2User oAuth2User
+	) {
+		if (oAuth2User == null || oAuth2User.getAttribute("id") == null) {
+			throw new CustomException(ErrorCode.UNAUTHORIZED);
+		}
+
+		String oauthUserId = oAuth2User.getAttribute("id").toString();
+		PlanChangeResponse response = planService.changePlan(request, oauthUserId);
+
+		return ResponseEntity.ok(BaseResponse.success(response));
+	}
+
+	@Operation(summary = "요금제 해지")
+	@DeleteMapping
+	public ResponseEntity<BaseResponse<PlanChangeResponse>> cancelPlan(
+			@AuthenticationPrincipal OAuth2User oAuth2User
+	) {
+		if (oAuth2User == null || oAuth2User.getAttribute("id") == null) {
+			throw new CustomException(ErrorCode.UNAUTHORIZED);
+		}
+
+		String oauthUserId = oAuth2User.getAttribute("id").toString();
+		PlanChangeResponse response = planService.cancelPlan(oauthUserId);
+		return ResponseEntity.ok(BaseResponse.success(response));
+	}
+}


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #84 

### 🔎 작업 내용

- [x] 요금제 전체 조회 (`GET /api/plans`)
- [x] 요금제 상세 조회 (`GET /api/plans/{planId}`)  
- [x] 컨트롤러 분리 (PlanController / UserPlanController)
- [x] Swagger UI 문서화 (상세 어노테이션 추가)
   - 요청/응답 예시 추가
   - 에러 코드별 응답 정의
   - 파라미터 설명 추가

### 📸 스크린샷
> 요금제 API 개발 완료!
<img width="522" alt="스크린샷 2025-06-13 오전 10 06 47" src="https://github.com/user-attachments/assets/a69ae5d3-8ad8-47b3-9ca0-3b26b7981842" />

> 상세 설명 추가
<img width="598" alt="스크린샷 2025-06-13 오전 10 07 04" src="https://github.com/user-attachments/assets/a2afbe75-9758-48c5-9347-ef0482395d99" />

### :loudspeaker: 전달사항
앞으로 스웨거 설명 이런식으로 추가해주세용
- 추가한 라이브러리나 특이 사항

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
