### PR TITLE
Fix: [EVER-172] SwaggerConfig 및 컨트롤러 인증 수정

### DIFF
--- a/src/main/java/com/team4ever/backend/domain/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/team4ever/backend/domain/attendance/controller/AttendanceController.java
@@ -1,35 +1,224 @@
 package com.team4ever.backend.domain.attendance.controller;
 
 import com.team4ever.backend.domain.attendance.dto.AttendanceDto;
-import com.team4ever.backend.domain.attendance.dto.AttendanceRequest;
 import com.team4ever.backend.domain.attendance.service.AttendanceService;
+import com.team4ever.backend.domain.user.Entity.User;
+import com.team4ever.backend.domain.user.repository.UserRepository;
 import com.team4ever.backend.global.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/attendances")
 @RequiredArgsConstructor
+@Tag(name = "출석 API", description = "출석 체크 및 출석 현황 관리 API (인증 필요)")
+@SecurityRequirement(name = "cookieAuth")
 public class AttendanceController {
 
     private final AttendanceService attendanceService;
+    private final UserRepository userRepository;
 
-    @Operation(summary = "오늘 출석하기")
+    @Operation(
+            summary = "오늘 출석하기",
+            description = """
+            현재 로그인한 사용자의 오늘 출석을 체크합니다.
+            
+            **출석 혜택:**
+            - 연속 출석 일수 증가
+            - 출석 포인트 적립
+            - 출석 보상 지급
+            """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "출석 체크 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                        {
+                          "success": true,
+                          "message": "출석 체크가 완료되었습니다.",
+                          "data": {
+                            "id": 123,
+                            "user_id": 1,
+                            "checked_date": "2025-06-15"
+                          }
+                        }
+                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "이미 출석 완료",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                        {
+                          "success": false,
+                          "message": "오늘은 이미 출석하셨습니다.",
+                          "data": null
+                        }
+                        """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "인증 필요")
+    })
     @PostMapping
-    public BaseResponse<AttendanceDto> checkToday(@RequestBody AttendanceRequest req) {
-        return BaseResponse.success(attendanceService.checkToday(req.getUserId()));
+    public BaseResponse<AttendanceDto> checkToday() {
+        log.info("출석 체크 요청");
+
+        Long userId = getCurrentUserIdAsLong();
+        AttendanceDto result = attendanceService.checkToday(userId);
+
+        log.info("출석 체크 완료 - userId: {}", userId);
+        return BaseResponse.success(result);
     }
 
-    @Operation(summary = "내 연속 출석 일수 조회")
+    @Operation(
+            summary = "내 연속 출석 일수 조회",
+            description = """
+            현재 로그인한 사용자의 연속 출석 일수를 조회합니다.
+            """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "요청 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                        {
+                          "success": true,
+                          "message": "요청 성공",
+                          "data": 15
+                        }
+                        """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "인증 필요")
+    })
     @GetMapping("/streak")
-    public BaseResponse<Integer> getStreak(@RequestParam Long userId) {
-        return BaseResponse.success(attendanceService.getCurrentStreak(userId));
+    public BaseResponse<Integer> getStreak() {
+        log.info("연속 출석 일수 조회 요청");
+
+        Long userId = getCurrentUserIdAsLong();
+        Integer streak = attendanceService.getCurrentStreak(userId);
+
+        log.info("연속 출석 일수 조회 완료 - userId: {}, streak: {}", userId, streak);
+        return BaseResponse.success(streak);
     }
 
-    @Operation(summary = "오늘 출석 여부 확인")
+    @Operation(
+            summary = "오늘 출석 여부 확인",
+            description = """
+            현재 로그인한 사용자의 오늘 출석 여부를 확인합니다.
+            
+            **응답값:**
+            - true: 오늘 출석 완료
+            - false: 오늘 아직 출석하지 않음
+            """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "요청 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "출석 완료한 경우",
+                                    value = """
+                        {
+                          "success": true,
+                          "message": "요청 성공,
+                          "data": true
+                        }
+                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "아직 출석하지 않은 경우",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                        {
+                          "success": true,
+                          "message": "요청 성공",
+                          "data": false
+                        }
+                        """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "인증 필요")
+    })
     @GetMapping("/today")
-    public BaseResponse<Boolean> isAttendedToday(@RequestParam Long userId) {
-        return BaseResponse.success(attendanceService.isAttendedToday(userId));
+    public BaseResponse<Boolean> isAttendedToday() {
+        log.info("오늘 출석 여부 확인 요청");
+
+        Long userId = getCurrentUserIdAsLong();
+        Boolean isAttended = attendanceService.isAttendedToday(userId);
+
+        log.info("출석 여부 확인 완료 - userId: {}, attended: {}", userId, isAttended);
+        return BaseResponse.success(isAttended);
+    }
+
+    /**
+     * SecurityContext에서 현재 사용자 ID 추출 (JWT 인터셉터에서 설정됨)
+     */
+    private String getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            log.error("인증되지 않은 사용자의 출석 API 접근 시도");
+            throw new RuntimeException("인증되지 않은 사용자입니다.");
+        }
+
+        String userId = (String) authentication.getPrincipal();
+        log.debug("현재 사용자 ID: {}", userId);
+        return userId;
+    }
+
+    /**
+     * JWT에서 추출한 User.userId(String)로 User 엔티티를 조회하여 PK(Long) 반환
+     */
+    private Long getCurrentUserIdAsLong() {
+        try {
+            String userIdStr = getCurrentUserId();
+
+            // User.userId(String)로 User 엔티티 조회
+            User user = userRepository.findByUserId(userIdStr)
+                    .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다: " + userIdStr));
+
+            Long userPkId = user.getId();
+            log.debug("JWT userId: {} -> User PK: {}", userIdStr, userPkId);
+
+            return userPkId;
+
+        } catch (Exception e) {
+            log.error("사용자 ID 변환 중 오류 발생: {}", e.getMessage());
+            throw new RuntimeException("사용자 정보를 조회할 수 없습니다.");
+        }
     }
 }

--- a/src/main/java/com/team4ever/backend/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/team4ever/backend/domain/coupon/controller/CouponController.java
@@ -1,89 +1,230 @@
 package com.team4ever.backend.domain.coupon.controller;
 
-import com.team4ever.backend.domain.coupon.dto.CouponClaimRequest;
 import com.team4ever.backend.domain.coupon.dto.CouponClaimResponse;
 import com.team4ever.backend.domain.coupon.dto.CouponResponse;
 import com.team4ever.backend.domain.coupon.dto.CouponUseResponse;
 import com.team4ever.backend.domain.coupon.service.CouponService;
-import com.team4ever.backend.global.exception.CustomException;
-import com.team4ever.backend.global.exception.ErrorCode;
+import com.team4ever.backend.domain.user.Entity.User;
+import com.team4ever.backend.domain.user.repository.UserRepository;
 import com.team4ever.backend.global.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.oauth2.core.user.OAuth2User;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/coupons")
 @RequiredArgsConstructor
+@Tag(name = "쿠폰 API", description = "쿠폰 조회, 발급, 사용 관련 API")
 public class CouponController {
 
     private final CouponService couponService;
+    private final UserRepository userRepository;
 
-    @Operation(summary = "전체 쿠폰 조회")
+    @Operation(
+            summary = "전체 쿠폰 조회",
+            description = """
+            모든 사용자가 이용할 수 있는 쿠폰 목록을 조회합니다.
+            """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "쿠폰 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                        {
+                          "success": true,
+                          "message": "쿠폰 목록 조회 성공",
+                          "data": [
+                            {
+                              "id": 1,
+                              "title": "스타벅스 10% 할인 쿠폰",
+                              "description": "모든 음료 10% 할인",
+                              "discountType": "PERCENTAGE",
+                              "discountValue": 10,
+                              "validUntil": "2025-12-31",
+                              "brand": {
+                                "id": 1,
+                                "name": "스타벅스",
+                                "imageUrl": "https://example.com/starbucks.png"
+                              }
+                            }
+                          ]
+                        }
+                        """
+                            )
+                    )
+            )
+    })
     @GetMapping
     public BaseResponse<List<CouponResponse>> getAllCoupons() {
+        log.info("전체 쿠폰 목록 조회 요청");
+
         // userId 없이 전체 쿠폰만 반환
-        return BaseResponse.success(
-                couponService.getAllCoupons(null)
-        );
+        List<CouponResponse> coupons = couponService.getAllCoupons(null);
+
+        log.info("쿠폰 목록 조회 완료 - 쿠폰 수: {}", coupons.size());
+        return BaseResponse.success(coupons);
     }
 
-    @Operation(summary = "특정 쿠폰 발급 요청")
+    @Operation(
+            summary = "특정 쿠폰 발급 요청",
+            description = """
+            특정 쿠폰을 현재 로그인한 사용자에게 발급합니다.
+            
+            **발급 조건:**
+            - 로그인된 사용자만 가능
+            - 쿠폰 발급 가능 수량 확인
+            - 중복 발급 방지
+            """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "쿠폰 발급 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                        {
+                          "success": true,
+                          "message": "쿠폰 발급이 완료되었습니다.",
+                          "data": {
+                            "couponId": 1,
+                            "title": "스타벅스 10% 할인 쿠폰",
+                            "claimedAt": "2025-06-15T18:30:00",
+                            "validUntil": "2025-12-31T23:59:59",
+                            "isUsed": false
+                          }
+                        }
+                        """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "쿠폰 발급 불가 (이미 발급받음, 수량 초과 등)"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+            @ApiResponse(responseCode = "404", description = "쿠폰을 찾을 수 없음")
+    })
+    @SecurityRequirement(name = "cookieAuth")
     @PostMapping("/{couponId}/claim")
     public BaseResponse<CouponClaimResponse> claimCoupon(
-            @PathVariable Integer couponId,
-            @AuthenticationPrincipal OAuth2User oAuth2User
+            @Parameter(description = "발급받을 쿠폰 ID", required = true, example = "1")
+            @PathVariable Integer couponId
     ) {
-        if (oAuth2User == null || oAuth2User.getAttribute("id") == null) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED);
-        }
+        log.info("쿠폰 발급 요청 - couponId: {}", couponId);
 
-        Long userId = Long.valueOf(oAuth2User.getAttribute("id").toString());
-
+        Long userId = getCurrentUserIdAsLong();
         CouponClaimResponse response = couponService.claimCoupon(userId, couponId);
+
+        log.info("쿠폰 발급 완료 - userId: {}, couponId: {}", userId, couponId);
         return BaseResponse.success(response);
     }
 
-
-
-
-
-
-    @Operation(summary = "특정 쿠폰 사용 처리")
+    @Operation(
+            summary = "특정 쿠폰 사용 처리",
+            description = """
+            보유한 쿠폰을 사용 처리합니다.
+            
+            **사용 조건:**
+            - 로그인된 사용자만 가능
+            - 보유한 쿠폰만 사용 가능
+            - 미사용 상태인 쿠폰만 사용 가능
+            - 유효기간 내 쿠폰만 사용 가능
+            """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "쿠폰 사용 처리 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                        {
+                          "success": true,
+                          "message": "쿠폰이 성공적으로 사용되었습니다.",
+                          "data": {
+                            "couponId": 1,
+                            "title": "스타벅스 10% 할인 쿠폰",
+                            "usedAt": "2025-06-15T18:30:00",
+                            "discountAmount": 500,
+                            "originalPrice": 5000,
+                            "finalPrice": 4500
+                          }
+                        }
+                        """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "쿠폰 사용 불가 (이미 사용됨, 만료됨 등)"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+            @ApiResponse(responseCode = "404", description = "보유한 쿠폰을 찾을 수 없음")
+    })
+    @SecurityRequirement(name = "cookieAuth")
     @PatchMapping("/{couponId}/use")
     public BaseResponse<CouponUseResponse> useCoupon(
-            @PathVariable Integer couponId,
-            @AuthenticationPrincipal OAuth2User oauth2User
+            @Parameter(description = "사용할 쿠폰 ID", required = true, example = "1")
+            @PathVariable Integer couponId
     ) {
-        if (oauth2User == null) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED);
-        }
+        log.info("쿠폰 사용 요청 - couponId: {}", couponId);
 
-        Object idAttr = oauth2User.getAttribute("id");
-        if (idAttr == null) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED);
-        }
+        Long userId = getCurrentUserIdAsLong();
+        CouponUseResponse response = couponService.useCoupon(userId, couponId);
 
-        Long userId = Long.valueOf(idAttr.toString());
-        return BaseResponse.success(
-                couponService.useCoupon(userId, couponId)
-        );
+        log.info("쿠폰 사용 완료 - userId: {}, couponId: {}", userId, couponId);
+        return BaseResponse.success(response);
     }
 
-    private Long extractUserId(OAuth2User oauth2User) {
-        Object idAttr = oauth2User.getAttribute("id");
-        if (idAttr == null) {
-            throw new IllegalStateException("OAuth2User에 'id' 속성이 없습니다.");
+    /**
+     * SecurityContext에서 현재 사용자 ID 추출
+     */
+    private String getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            log.error("인증되지 않은 사용자의 쿠폰 API 접근 시도");
+            throw new RuntimeException("인증되지 않은 사용자입니다.");
         }
+
+        String userId = (String) authentication.getPrincipal();
+        log.debug("현재 사용자 ID: {}", userId);
+        return userId;
+    }
+
+    /**
+     * JWT에서 추출한 User.userId(String)로 User 엔티티를 조회하여 PK(Long) 반환
+     */
+    private Long getCurrentUserIdAsLong() {
         try {
-            return Long.valueOf(idAttr.toString());
-        } catch (NumberFormatException e) {
-            throw new IllegalStateException("'id' 속성의 형식이 올바르지 않습니다: " + idAttr);
+            String userIdStr = getCurrentUserId();
+
+            // User.userId(String)로 User 엔티티 조회
+            User user = userRepository.findByUserId(userIdStr)
+                    .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다: " + userIdStr));
+
+            Long userPkId = user.getId();
+            log.debug("JWT userId: {} -> User PK: {}", userIdStr, userPkId);
+
+            return userPkId;
+
+        } catch (Exception e) {
+            log.error("사용자 ID 변환 중 오류 발생: {}", e.getMessage());
+            throw new RuntimeException("사용자 정보를 조회할 수 없습니다.");
         }
     }
-
 }

--- a/src/main/java/com/team4ever/backend/domain/plan/controller/UserPlanController.java
+++ b/src/main/java/com/team4ever/backend/domain/plan/controller/UserPlanController.java
@@ -4,168 +4,218 @@ import com.team4ever.backend.domain.plan.dto.PlanChangeRequest;
 import com.team4ever.backend.domain.plan.dto.PlanChangeResponse;
 import com.team4ever.backend.domain.plan.dto.PlanResponse;
 import com.team4ever.backend.domain.plan.service.PlanService;
-import com.team4ever.backend.global.exception.CustomException;
-import com.team4ever.backend.global.exception.ErrorCode;
 import com.team4ever.backend.global.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import jakarta.validation.Valid;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/user/plans")
 @RequiredArgsConstructor
 @Tag(name = "사용자 요금제 API", description = "사용자 개인 요금제 관리 API (인증 필요)")
-@SecurityRequirement(name = "bearerAuth")
+@SecurityRequirement(name = "cookieAuth")  // bearerAuth → cookieAuth로 변경
 public class UserPlanController {
 
 	private final PlanService planService;
 
 	@Operation(
 			summary = "내가 사용중인 요금제 조회",
-			description = "현재 로그인한 사용자가 사용중인 요금제 정보를 조회합니다."
+			description = """
+            현재 로그인한 사용자가 사용중인 요금제 정보를 조회합니다.
+            
+            **반환 정보:**
+            - 현재 활성 요금제 상세 정보
+            """
 	)
 	@ApiResponses(value = {
 			@ApiResponse(
 					responseCode = "200",
 					description = "사용자 요금제 조회 성공",
-					content = @Content(schema = @Schema(implementation = BaseResponse.class))
+					content = @Content(
+							mediaType = "application/json",
+							schema = @Schema(implementation = BaseResponse.class),
+							examples = @ExampleObject(
+									value = """
+                        {
+                          "success": true,
+                          "message": "사용자 요금제 조회 성공",
+                          "data": {
+                            "id": 2,
+                            "name": "프리미엄 요금제",
+                            "price": "19900",
+                            "description": "모든 기능을 이용할 수 있는 프리미엄 요금제입니다.",
+                            "data": "무제한",
+                            "speed": "5G",
+                            "sms": "무제한",
+                            "voice": "무제한",
+                            "share_data": "10GB"
+                          }
+                        }
+                        """
+							)
+					)
 			),
 			@ApiResponse(
 					responseCode = "401",
 					description = "인증되지 않은 사용자",
-					content = @Content(schema = @Schema(implementation = BaseResponse.class))
+					content = @Content(
+							mediaType = "application/json",
+							examples = @ExampleObject(
+									value = """
+                        {
+                          "success": false,
+                          "message": "인증이 필요합니다.",
+                          "data": null
+                        }
+                        """
+							)
+					)
 			),
 			@ApiResponse(
 					responseCode = "404",
-					description = "사용자 또는 요금제를 찾을 수 없음",
-					content = @Content(schema = @Schema(implementation = BaseResponse.class))
+					description = "사용자 또는 요금제를 찾을 수 없음"
 			),
 			@ApiResponse(
 					responseCode = "500",
-					description = "서버 내부 오류",
-					content = @Content(schema = @Schema(implementation = BaseResponse.class))
+					description = "서버 내부 오류"
 			)
 	})
 	@GetMapping
-	public ResponseEntity<BaseResponse<PlanResponse>> getCurrentPlan(
-			@Parameter(hidden = true)
-			@AuthenticationPrincipal OAuth2User oAuth2User
-	) {
-		if (oAuth2User == null || oAuth2User.getAttribute("id") == null) {
-			throw new CustomException(ErrorCode.UNAUTHORIZED);
-		}
+	public ResponseEntity<BaseResponse<PlanResponse>> getCurrentPlan() {
+		log.info("사용자 요금제 조회 요청");
 
-		String oauthUserId = oAuth2User.getAttribute("id").toString();
-		PlanResponse response = planService.getCurrentPlan(oauthUserId);
+		String userId = getCurrentUserId();
+		PlanResponse response = planService.getCurrentPlan(userId);
 
+		log.info("사용자 요금제 조회 완료 - userId: {}, planName: {}", userId, response.getName());
 		return ResponseEntity.ok(BaseResponse.success(response));
 	}
 
 	@Operation(
 			summary = "요금제 변경",
-			description = "현재 로그인한 사용자의 요금제를 변경합니다."
+			description = """
+            현재 로그인한 사용자의 요금제를 변경합니다.
+            
+            **변경 프로세스:**
+            1. 기존 요금제 확인
+            2. 새 요금제 유효성 검증
+            3. 결제 정보 확인
+            4. 요금제 변경 처리
+            """
 	)
 	@ApiResponses(value = {
 			@ApiResponse(
 					responseCode = "200",
 					description = "요금제 변경 성공",
-					content = @Content(schema = @Schema(implementation = BaseResponse.class))
+					content = @Content(
+							mediaType = "application/json",
+							examples = @ExampleObject(
+									value = """
+                        {
+                          "success": true,
+                          "message": "요금제 변경이 완료되었습니다.",
+                          "data": {
+                            "plan_id": 2,
+                            "plan_name": "프리미엄 요금제",
+                            "changed_at": "2025-06-15T10:30:00",
+                            "message": "요금제가 성공적으로 변경되었습니다."
+                          }
+                        }
+                        """
+							)
+					)
 			),
-			@ApiResponse(
-					responseCode = "400",
-					description = "잘못된 요청 (이미 사용중인 요금제 등)",
-					content = @Content(schema = @Schema(implementation = BaseResponse.class))
-			),
-			@ApiResponse(
-					responseCode = "401",
-					description = "인증되지 않은 사용자",
-					content = @Content(schema = @Schema(implementation = BaseResponse.class))
-			),
-			@ApiResponse(
-					responseCode = "404",
-					description = "사용자 또는 요금제를 찾을 수 없음",
-					content = @Content(schema = @Schema(implementation = BaseResponse.class))
-			),
-			@ApiResponse(
-					responseCode = "500",
-					description = "서버 내부 오류",
-					content = @Content(schema = @Schema(implementation = BaseResponse.class))
-			)
+			@ApiResponse(responseCode = "400", description = "잘못된 요청 (이미 사용중인 요금제 등)"),
+			@ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+			@ApiResponse(responseCode = "404", description = "사용자 또는 요금제를 찾을 수 없음"),
+			@ApiResponse(responseCode = "500", description = "서버 내부 오류")
 	})
 	@PostMapping
 	public ResponseEntity<BaseResponse<PlanChangeResponse>> changePlan(
-			@Parameter(
-					description = "요금제 변경 요청 정보",
-					required = true
-			)
-			@Valid @RequestBody PlanChangeRequest request,
-			@Parameter(hidden = true)
-			@AuthenticationPrincipal OAuth2User oAuth2User
+			@Parameter(description = "요금제 변경 요청 정보", required = true)
+			@Valid @RequestBody PlanChangeRequest request
 	) {
-		if (oAuth2User == null || oAuth2User.getAttribute("id") == null) {
-			throw new CustomException(ErrorCode.UNAUTHORIZED);
-		}
+		log.info("요금제 변경 요청 - planId: {}", request.getPlanId());
 
-		String oauthUserId = oAuth2User.getAttribute("id").toString();
-		PlanChangeResponse response = planService.changePlan(request, oauthUserId);
+		String userId = getCurrentUserId();
+		PlanChangeResponse response = planService.changePlan(request, userId);
 
+		log.info("요금제 변경 완료 - userId: {}, newPlan: {}", userId, response.getPlanName());
 		return ResponseEntity.ok(BaseResponse.success(response));
 	}
 
 	@Operation(
 			summary = "요금제 해지",
-			description = "현재 로그인한 사용자의 요금제를 해지합니다."
+			description = """
+            현재 로그인한 사용자의 요금제를 해지합니다.
+            """
 	)
 	@ApiResponses(value = {
 			@ApiResponse(
 					responseCode = "200",
 					description = "요금제 해지 성공",
-					content = @Content(schema = @Schema(implementation = BaseResponse.class))
+					content = @Content(
+							mediaType = "application/json",
+							examples = @ExampleObject(
+									value = """
+                        {
+                          "success": true,
+                          "message": "요금제 해지가 완료되었습니다.",
+                          "data": {
+                            "plan_id": null,
+                            "plan_name": "해지됨",
+                            "changed_at": "2025-06-15T10:30:00",
+                            "message": "요금제가 성공적으로 해지되었습니다."
+                          }
+                        }
+                        """
+							)
+					)
 			),
-			@ApiResponse(
-					responseCode = "400",
-					description = "해지할 요금제가 없음",
-					content = @Content(schema = @Schema(implementation = BaseResponse.class))
-			),
-			@ApiResponse(
-					responseCode = "401",
-					description = "인증되지 않은 사용자",
-					content = @Content(schema = @Schema(implementation = BaseResponse.class))
-			),
-			@ApiResponse(
-					responseCode = "404",
-					description = "사용자를 찾을 수 없음",
-					content = @Content(schema = @Schema(implementation = BaseResponse.class))
-			),
-			@ApiResponse(
-					responseCode = "500",
-					description = "서버 내부 오류",
-					content = @Content(schema = @Schema(implementation = BaseResponse.class))
-			)
+			@ApiResponse(responseCode = "400", description = "해지할 요금제가 없음"),
+			@ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+			@ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음"),
+			@ApiResponse(responseCode = "500", description = "서버 내부 오류")
 	})
 	@DeleteMapping
-	public ResponseEntity<BaseResponse<PlanChangeResponse>> cancelPlan(
-			@Parameter(hidden = true)
-			@AuthenticationPrincipal OAuth2User oAuth2User
-	) {
-		if (oAuth2User == null || oAuth2User.getAttribute("id") == null) {
-			throw new CustomException(ErrorCode.UNAUTHORIZED);
+	public ResponseEntity<BaseResponse<PlanChangeResponse>> cancelPlan() {
+		log.info("요금제 해지 요청");
+
+		String userId = getCurrentUserId();
+		PlanChangeResponse response = planService.cancelPlan(userId);
+
+		log.info("요금제 해지 완료 - userId: {}, canceledPlan: {}", userId, response.getPlanName());
+		return ResponseEntity.ok(BaseResponse.success(response));
+	}
+
+	/**
+	 * SecurityContext에서 현재 사용자 ID 추출
+	 */
+	private String getCurrentUserId() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		if (authentication == null || !authentication.isAuthenticated()) {
+			log.error("인증되지 않은 사용자의 접근 시도");
+			throw new RuntimeException("인증되지 않은 사용자입니다.");
 		}
 
-		String oauthUserId = oAuth2User.getAttribute("id").toString();
-		PlanChangeResponse response = planService.cancelPlan(oauthUserId);
-		return ResponseEntity.ok(BaseResponse.success(response));
+		String userId = (String) authentication.getPrincipal();
+		log.debug("현재 사용자 ID: {}", userId);
+
+		return userId;
 	}
 }

--- a/src/main/java/com/team4ever/backend/domain/subscriptions/controller/SubscriptionController.java
+++ b/src/main/java/com/team4ever/backend/domain/subscriptions/controller/SubscriptionController.java
@@ -2,14 +2,23 @@ package com.team4ever.backend.domain.subscriptions.controller;
 
 import com.team4ever.backend.domain.subscriptions.dto.*;
 import com.team4ever.backend.domain.subscriptions.service.SubscriptionService;
-import com.team4ever.backend.global.exception.CustomException;
-import com.team4ever.backend.global.exception.ErrorCode;
+import com.team4ever.backend.domain.user.Entity.User;
+import com.team4ever.backend.domain.user.repository.UserRepository;
 import com.team4ever.backend.global.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import jakarta.validation.Valid;
@@ -17,68 +26,293 @@ import java.util.List;
 
 import static com.team4ever.backend.global.response.BaseResponse.*;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/subscriptions")
 @RequiredArgsConstructor
+@Tag(name = "📺 구독 API", description = "구독 상품 조회, 가입, 해지 관련 API")
 public class SubscriptionController {
 
 	private final SubscriptionService subscriptionService;
+	private final UserRepository userRepository;
 
-	@Operation(summary = "메인 구독 상품 전체 조회")
+	@Operation(
+			summary = "메인 구독 상품 전체 조회",
+			description = """
+            메인 페이지에 표시되는 구독 상품 목록을 조회합니다.
+            
+            **특징:**
+            - 인증 불필요 (공개 API)
+            - 추천 구독 상품 위주로 구성
+            - 인기순으로 정렬하여 제공
+            """
+	)
+	@ApiResponses(value = {
+			@ApiResponse(
+					responseCode = "200",
+					description = "메인 구독 상품 조회 성공",
+					content = @Content(
+							mediaType = "application/json",
+							examples = @ExampleObject(
+									value = """
+                        {
+                          "success": true,
+                          "message": "메인 구독 상품 조회 성공",
+                          "data": [
+                            {
+                              "id": 1,
+                              "title": "넷플릭스 프리미엄",
+                              "image_url": "https://example.com/netflix.png",
+                              "category": "ENTERTAINMENT",
+                              "price": 17000
+                            }
+                          ]
+                        }
+                        """
+							)
+					)
+			)
+	})
 	@GetMapping("/main")
 	public ResponseEntity<BaseResponse<List<SubscriptionResponse>>> getMainSubscriptions() {
-		return ResponseEntity.ok(success(
-				subscriptionService.getMainSubscriptions()
-		));
+		log.info("메인 구독 상품 전체 조회 요청");
+
+		List<SubscriptionResponse> subscriptions = subscriptionService.getMainSubscriptions();
+
+		log.info("메인 구독 상품 조회 완료 - 상품 수: {}", subscriptions.size());
+		return ResponseEntity.ok(success(subscriptions));
 	}
 
-	@Operation(summary = "라이프 구독 브랜드 조회 (전체 or 카테고리별)")
+	@Operation(
+			summary = "라이프 구독 브랜드 조회 (전체 or 카테고리별)",
+			description = """
+            라이프스타일 관련 구독 브랜드를 조회합니다.
+            
+            **조회 옵션:**
+            - category 없음: 전체 브랜드 조회
+            - category 지정: 특정 카테고리의 브랜드만 조회
+            
+            **지원 카테고리:**
+            - 도서/콘텐츠
+            - 디저트/음료
+            - 편의점/쇼핑
+            - 카페/음료
+            - 베이커리
+            """
+	)
+	@ApiResponses(value = {
+			@ApiResponse(
+					responseCode = "200",
+					description = "브랜드 조회 성공",
+					content = @Content(
+							mediaType = "application/json",
+							examples = @ExampleObject(
+									value = """
+                        {
+                          "success": true,
+                          "message": "브랜드 조회 성공",
+                          "data": [
+                            {
+                              "id": 1,
+                              "title": "베스킨라빈스",
+                              "image_url": "https://example.com/br.png",
+                              "category": "디저트/음료"
+                            }
+                          ]
+                        }
+                        """
+							)
+					)
+			),
+			@ApiResponse(responseCode = "400", description = "잘못된 카테고리")
+	})
 	@GetMapping("/brands")
 	public ResponseEntity<BaseResponse<List<BrandResponse>>> getLifeSubscriptionBrands(
-			@RequestParam(required = false) String category) {
+			@Parameter(
+					description = "브랜드 카테고리 (선택사항)",
+					example = "도서/콘텐츠",
+					schema = @Schema(type = "string", allowableValues = {"도서/콘텐츠", "디저트/음료", "편의점/쇼핑", "카페/음료", "베이커리"})
+			)
+			@RequestParam(required = false) String category
+	) {
+		log.info("라이프 구독 브랜드 조회 요청 - category: {}", category);
 
-		// 디버깅용 로그
 		if (category != null) {
-			System.out.println("컨트롤러에서 받은 원본 카테고리: '" + category + "'");
+			log.debug("컨트롤러에서 받은 원본 카테고리: '{}'", category);
 		}
 
-		return ResponseEntity.ok(success(
-				subscriptionService.getLifeSubscriptionBrands(category)
-		));
+		List<BrandResponse> brands = subscriptionService.getLifeSubscriptionBrands(category);
+
+		log.info("브랜드 조회 완료 - category: {}, 브랜드 수: {}", category, brands.size());
+		return ResponseEntity.ok(success(brands));
 	}
 
-
-	@Operation(summary = "구독 상품 가입")
+	@Operation(
+			summary = "구독 상품 가입",
+			description = """
+            특정 구독 상품에 가입합니다.
+            
+            **가입 프로세스:**
+            1. 로그인 사용자 확인
+            2. 구독 상품 유효성 검증
+            3. 중복 가입 방지 체크
+            4. 결제 정보 확인
+            5. 구독 가입 처리
+            """
+	)
+	@ApiResponses(value = {
+			@ApiResponse(
+					responseCode = "200",
+					description = "구독 가입 성공",
+					content = @Content(
+							mediaType = "application/json",
+							examples = @ExampleObject(
+									value = """
+                        {
+                          "success": true,
+                          "message": "구독 가입이 완료되었습니다.",
+                          "data": {
+                            "subscription_combination_id": 123,
+                            "brand_id": 1,
+                            "price": 17000
+                          }
+                        }
+                        """
+							)
+					)
+			),
+			@ApiResponse(responseCode = "400", description = "가입 불가 (이미 가입됨, 잘못된 요청 등)"),
+			@ApiResponse(responseCode = "401", description = "인증 필요"),
+			@ApiResponse(responseCode = "404", description = "구독 상품 또는 브랜드를 찾을 수 없음")
+	})
+	@SecurityRequirement(name = "cookieAuth")
 	@PostMapping("/subscribe")
 	public ResponseEntity<BaseResponse<SubscribeResponse>> subscribe(
-			@RequestBody SubscribeRequest request,
-			@AuthenticationPrincipal OAuth2User oAuth2User
+			@Parameter(
+					description = "구독 가입 요청 정보",
+					required = true,
+					content = @Content(
+							examples = @ExampleObject(
+									value = """
+                        {
+                          "subscription_id": 1,
+                          "brand_id": 1
+                        }
+                        """
+							)
+					)
+			)
+			@RequestBody @Valid SubscribeRequest request
 	) {
-		if (oAuth2User == null || oAuth2User.getAttribute("id") == null) {
-			throw new CustomException(ErrorCode.UNAUTHORIZED);
-		}
+		log.info("구독 가입 요청 - subscriptionId: {}, brandId: {}",
+				request.getSubscriptionId(), request.getBrandId());
 
-		// OAuth에서 받은 사용자 ID를 String으로 처리
-		String oauthUserId = oAuth2User.getAttribute("id").toString();
+		String userId = getCurrentUserId();
+		SubscribeResponse response = subscriptionService.subscribe(request, userId);
 
-		SubscribeResponse response = subscriptionService.subscribe(request, oauthUserId);
+		log.info("구독 가입 완료 - userId: {}, subscriptionCombinationId: {}",
+				userId, response.getSubscriptionCombinationId());
 		return ResponseEntity.ok(BaseResponse.success(response));
 	}
 
-
-	@Operation(summary = "구독 상품 해지")
+	@Operation(
+			summary = "구독 상품 해지",
+			description = """
+            현재 가입 중인 구독 상품을 해지합니다.
+            
+            **해지 프로세스:**
+            1. 로그인 사용자 확인
+            2. 구독 조합 ID 유효성 검증
+            3. 해지 권한 확인 (본인 구독인지)
+            4. 구독 해지 처리
+            
+            **디버깅 정보:**
+            - JWT에서 추출된 사용자 ID 로깅
+            - User 테이블 조회 결과 로깅
+            - UserSubscriptionCombination 조회 결과 로깅
+            """
+	)
+	@ApiResponses(value = {
+			@ApiResponse(
+					responseCode = "200",
+					description = "구독 해지 성공",
+					content = @Content(
+							mediaType = "application/json",
+							examples = @ExampleObject(
+									value = """
+                        {
+                          "success": true,
+                          "message": "구독 해지가 완료되었습니다.",
+                          "data": {
+                            "subscription_combination_id": 123,
+                            "message": "구독이 성공적으로 해지되었습니다."
+                          }
+                        }
+                        """
+							)
+					)
+			),
+			@ApiResponse(responseCode = "400", description = "해지 불가 (이미 해지됨, 잘못된 요청 등)"),
+			@ApiResponse(responseCode = "401", description = "인증 필요"),
+			@ApiResponse(responseCode = "403", description = "해지 권한 없음"),
+			@ApiResponse(responseCode = "404", description = "구독을 찾을 수 없음")
+	})
+	@SecurityRequirement(name = "cookieAuth")
 	@DeleteMapping("/unsubscribe")
 	public ResponseEntity<BaseResponse<UnsubscribeResponse>> unsubscribe(
-			@RequestBody UnsubscribeRequest request,
-			@AuthenticationPrincipal OAuth2User oAuth2User
+			@Parameter(
+					description = "구독 해지 요청 정보",
+					required = true,
+					content = @Content(
+							examples = @ExampleObject(
+									value = """
+                        {
+                          "subscription_combination_id": 4
+                        }
+                        """
+							)
+					)
+			)
+			@RequestBody @Valid UnsubscribeRequest request
 	) {
-		if (oAuth2User == null || oAuth2User.getAttribute("id") == null) {
-			throw new CustomException(ErrorCode.UNAUTHORIZED);
+		log.info("=== 구독 해지 요청 시작 ===");
+		log.info("요청된 subscriptionCombinationId: {}", request.getSubscriptionCombinationId());
+
+		// JWT에서 사용자 ID 추출 및 디버깅
+		String jwtUserId = getCurrentUserId();
+		log.info("JWT에서 추출된 사용자 ID: {}", jwtUserId);
+
+		// User 조회 및 PK 확인
+		User user = userRepository.findByUserId(jwtUserId)
+				.orElseThrow(() -> {
+					log.error("사용자를 찾을 수 없습니다. userId: {}", jwtUserId);
+					return new RuntimeException("사용자를 찾을 수 없습니다.");
+				});
+
+		Long userPkId = user.getId();
+		log.info("User 조회 성공 - JWT userId: {} -> User PK: {}", jwtUserId, userPkId);
+
+		UnsubscribeResponse response = subscriptionService.unsubscribe(request, jwtUserId);
+
+		log.info("구독 해지 완료 - userId: {}, subscriptionCombinationId: {}",
+				jwtUserId, response.getSubscriptionCombinationId());
+		log.info("=== 구독 해지 요청 완료 ===");
+
+		return ResponseEntity.ok(BaseResponse.success(response));
+	}
+
+	/**
+	 * SecurityContext에서 현재 사용자 ID 추출
+	 */
+	private String getCurrentUserId() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		if (authentication == null || !authentication.isAuthenticated()) {
+			log.error("인증되지 않은 사용자의 구독 API 접근 시도");
+			throw new RuntimeException("인증되지 않은 사용자입니다.");
 		}
 
-		String oauthUserId = oAuth2User.getAttribute("id").toString();
-
-		UnsubscribeResponse response = subscriptionService.unsubscribe(request, oauthUserId);
-		return ResponseEntity.ok(BaseResponse.success(response));
+		String userId = (String) authentication.getPrincipal();
+		log.debug("SecurityContext에서 추출된 사용자 ID: {}", userId);
+		return userId;
 	}
 }

--- a/src/main/java/com/team4ever/backend/domain/subscriptions/controller/SubscriptionController.java
+++ b/src/main/java/com/team4ever/backend/domain/subscriptions/controller/SubscriptionController.java
@@ -30,7 +30,7 @@ import static com.team4ever.backend.global.response.BaseResponse.*;
 @RestController
 @RequestMapping("/api/subscriptions")
 @RequiredArgsConstructor
-@Tag(name = "📺 구독 API", description = "구독 상품 조회, 가입, 해지 관련 API")
+@Tag(name = "구독 API", description = "구독 상품 조회, 가입, 해지 관련 API")
 public class SubscriptionController {
 
 	private final SubscriptionService subscriptionService;

--- a/src/main/java/com/team4ever/backend/domain/subscriptions/repository/UserSubscriptionCombinationRepository.java
+++ b/src/main/java/com/team4ever/backend/domain/subscriptions/repository/UserSubscriptionCombinationRepository.java
@@ -17,20 +17,21 @@ public interface UserSubscriptionCombinationRepository extends JpaRepository<Use
 	Optional<UserSubscriptionCombination> findByUserIdAndSubscriptionCombinationId(Long userId, Integer subscriptionCombinationId);
 
 	@Query("""
-        SELECT new com.team4ever.backend.domain.user.dto.UserSubscriptionDto(
-            usc.id,
-            s.title,
-            b.name,
-            usc.price,
-            usc.createdAt
-        )
-        FROM UserSubscriptionCombination usc
-        JOIN SubscriptionCombination sc ON usc.subscriptionCombinationId = sc.id
-        JOIN Subscription s ON sc.subscriptionId = s.id
-        JOIN Brand b ON sc.brandId = b.id
-        WHERE usc.userId = :userId
-        ORDER BY usc.createdAt DESC
-    """)
+    SELECT new com.team4ever.backend.domain.user.dto.UserSubscriptionDto(
+        usc.id,
+        usc.subscriptionCombinationId,
+        s.title,
+        b.name,
+        usc.price,
+        usc.createdAt
+    )
+    FROM UserSubscriptionCombination usc
+    JOIN SubscriptionCombination sc ON usc.subscriptionCombinationId = sc.id
+    JOIN Subscription s ON sc.subscriptionId = s.id
+    JOIN Brand b ON sc.brandId = b.id
+    WHERE usc.userId = :userId
+    ORDER BY usc.createdAt DESC
+""")
 	List<UserSubscriptionDto> findUserSubscriptionsWithDetails(@Param("userId") Long userId);
 
 	long countByUserId(Long userId);

--- a/src/main/java/com/team4ever/backend/domain/ubti/controller/UBTIController.java
+++ b/src/main/java/com/team4ever/backend/domain/ubti/controller/UBTIController.java
@@ -28,7 +28,7 @@ import reactor.core.publisher.Mono;
 @RestController
 @RequestMapping("/api/ubti")
 @RequiredArgsConstructor
-@Tag(name = "🧠 UBTI API", description = "UBTI 타코시그널 테스트 API (인증 필요)")
+@Tag(name = "UBTI API", description = "UBTI 타코시그널 테스트 API (인증 필요)")
 @SecurityRequirement(name = "cookieAuth")
 public class UBTIController {
 

--- a/src/main/java/com/team4ever/backend/domain/ubti/controller/UBTIController.java
+++ b/src/main/java/com/team4ever/backend/domain/ubti/controller/UBTIController.java
@@ -3,6 +3,8 @@ package com.team4ever.backend.domain.ubti.controller;
 import com.team4ever.backend.domain.ubti.dto.UBTIRequest;
 import com.team4ever.backend.domain.ubti.dto.UBTIResult;
 import com.team4ever.backend.domain.ubti.service.UBTIService;
+import com.team4ever.backend.domain.user.Entity.User;
+import com.team4ever.backend.domain.user.repository.UserRepository;
 import com.team4ever.backend.global.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -10,11 +12,14 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -23,33 +28,60 @@ import reactor.core.publisher.Mono;
 @RestController
 @RequestMapping("/api/ubti")
 @RequiredArgsConstructor
-@Tag(name = "UBTI", description = "UBTI 타코시그널 테스트 API")
+@Tag(name = "🧠 UBTI API", description = "UBTI 타코시그널 테스트 API (인증 필요)")
+@SecurityRequirement(name = "cookieAuth")
 public class UBTIController {
 
 	private final UBTIService ubtiService;
+	private final UserRepository userRepository;
 
 	@Operation(
 			summary = "UBTI 질문 스트리밍",
-			description = "UBTI 질문을 실시간으로 스트리밍하여 전송합니다. tone 파라미터로 말투를 선택할 수 있습니다."
+			description = """
+            UBTI 질문을 실시간으로 스트리밍하여 전송합니다.
+            
+            **인증 필요:** 로그인한 사용자만 이용 가능
+            
+            **tone 파라미터:**
+            - `general`: 정중하고 전문적인 톤
+            - `muneoz`: 친근하고 활발한 무너즈 캐릭터 톤
+            """
 	)
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "질문 스트리밍 성공"),
+			@ApiResponse(responseCode = "401", description = "인증 필요"),
+			@ApiResponse(responseCode = "400", description = "잘못된 요청"),
+			@ApiResponse(responseCode = "500", description = "서버 내부 오류")
+	})
 	@PostMapping(
 			value = "/question",
 			consumes = MediaType.APPLICATION_JSON_VALUE,
 			produces = MediaType.TEXT_EVENT_STREAM_VALUE
 	)
 	public Flux<ServerSentEvent<String>> nextQuestion(@RequestBody UBTIRequest req) {
+		log.info("=== UBTI 질문 요청 시작 ===");
+
+		// 인증된 사용자 정보 추가
+		String userId = getCurrentUserId();
+		Long userPkId = getCurrentUserPkId();
+
 		// tone 검증
 		String tone = validateTone(req.getTone());
 		req.setTone(tone);
 
-		log.info("UBTI 질문 요청 - session_id: {}, tone: {}", req.getSession_id(), tone);
+		log.info("UBTI 질문 요청 - userId: {}, userPK: {}, session_id: {}, tone: {}",
+				userId, userPkId, req.getSession_id(), tone);
 
 		return ubtiService.nextQuestionStream(req);
 	}
 
 	@Operation(
 			summary = "UBTI 검사 최종 결과 조회",
-			description = "모든 질문 완료 후 UBTI 타입과 요금제/구독 서비스 추천 결과를 반환합니다. tone 파라미터로 말투를 선택할 수 있습니다."
+			description = """
+            모든 질문 완료 후 UBTI 타입과 요금제/구독 서비스 추천 결과를 반환합니다.
+            
+            **인증 필요:** 로그인한 사용자만 이용 가능
+            """
 	)
 	@ApiResponses({
 			@ApiResponse(
@@ -63,37 +95,46 @@ public class UBTIController {
 											name = "일반 말투 결과",
 											description = "정중한 말투로 응답",
 											value = """
-                        {
-                          "status": 200,
-                          "message": "요청 성공",
-                          "data": {
-                            "ubti_type": {
-                              "description": "편안한 소통을 좋아하는 타입입니다."
-                            },
-                            "summary": "고객님의 통신 성향을 분석한 결과입니다."
-                          }
-                        }
-                        """
+                            {
+                              "status": 200,
+                              "message": "요청 성공",
+                              "data": {
+                                "ubti_type": {
+                                  "description": "편안한 소통을 좋아하는 타입입니다."
+                                },
+                                "summary": "고객님의 통신 성향을 분석한 결과입니다.",
+                                "recommendations": {
+                                  "plans": ["프리미엄 요금제"],
+                                  "subscriptions": ["넷플릭스", "유튜브 프리미엄"]
+                                }
+                              }
+                            }
+                            """
 									),
 									@ExampleObject(
 											name = "무너즈 말투 결과",
 											description = "친근한 말투로 응답",
 											value = """
-                        {
-                          "status": 200,
-                          "message": "요청 성공",
-                          "data": {
-                            "ubti_type": {
-                              "description": "편안한 소통 완전 좋아하는 타입이야! 💜"
-                            },
-                            "summary": "네 답변 보니까 완전 이런 스타일이네! 🔥"
-                          }
-                        }
-                        """
+                            {
+                              "status": 200,
+                              "message": "요청 성공",
+                              "data": {
+                                "ubti_type": {
+                                  "description": "편안한 소통 완전 좋아하는 타입이야! 💜"
+                                },
+                                "summary": "네 답변 보니까 완전 이런 스타일이네! 🔥",
+                                "recommendations": {
+                                  "plans": ["무제한 요금제 추천해!"],
+                                  "subscriptions": ["넷플릭스 꼭 써봐!", "유튜브 프리미엄 최고야!"]
+                                }
+                              }
+                            }
+                            """
 									)
 							}
 					)
 			),
+			@ApiResponse(responseCode = "401", description = "인증 필요"),
 			@ApiResponse(responseCode = "400", description = "잘못된 요청"),
 			@ApiResponse(responseCode = "500", description = "서버 내부 오류")
 	})
@@ -103,13 +144,56 @@ public class UBTIController {
 			produces = MediaType.APPLICATION_JSON_VALUE
 	)
 	public Mono<BaseResponse<UBTIResult>> finalResult(@RequestBody UBTIRequest req) {
+		log.info("=== UBTI 결과 요청 시작 ===");
+
+		// 인증된 사용자 정보 추가
+		String userId = getCurrentUserId();
+		Long userPkId = getCurrentUserPkId();
+
 		// tone 검증
 		String tone = validateTone(req.getTone());
 		req.setTone(tone);
 
-		log.info("UBTI 결과 요청 - session_id: {}, tone: {}", req.getSession_id(), tone);
+		log.info("UBTI 결과 요청 - userId: {}, userPK: {}, session_id: {}, tone: {}",
+				userId, userPkId, req.getSession_id(), tone);
 
 		return ubtiService.finalResultWrapped(req);
+	}
+
+	/**
+	 * 현재 인증된 사용자 ID 추출 (필수)
+	 */
+	private String getCurrentUserId() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		if (authentication == null || !authentication.isAuthenticated()) {
+			log.error("인증되지 않은 사용자의 UBTI API 접근 시도");
+			throw new RuntimeException("로그인이 필요한 서비스입니다.");
+		}
+
+		String userId = (String) authentication.getPrincipal();
+		log.debug("현재 사용자 ID: {}", userId);
+		return userId;
+	}
+
+	/**
+	 * 현재 사용자의 PK 추출
+	 */
+	private Long getCurrentUserPkId() {
+		try {
+			String userIdStr = getCurrentUserId();
+
+			User user = userRepository.findByUserId(userIdStr)
+					.orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다: " + userIdStr));
+
+			Long userPkId = user.getId();
+			log.debug("JWT userId: {} -> User PK: {}", userIdStr, userPkId);
+
+			return userPkId;
+
+		} catch (Exception e) {
+			log.error("사용자 ID 변환 중 오류 발생: {}", e.getMessage());
+			throw new RuntimeException("사용자 정보를 조회할 수 없습니다.");
+		}
 	}
 
 	/**

--- a/src/main/java/com/team4ever/backend/domain/user/Controller/UserController.java
+++ b/src/main/java/com/team4ever/backend/domain/user/Controller/UserController.java
@@ -5,25 +5,31 @@ import com.team4ever.backend.domain.user.dto.CreateUserRequest;
 import com.team4ever.backend.domain.user.dto.LikedCouponsResponse;
 import com.team4ever.backend.domain.user.dto.UserResponse;
 import com.team4ever.backend.domain.user.dto.UserSubscriptionListResponse;
-import com.team4ever.backend.global.exception.CustomException;
-import com.team4ever.backend.global.exception.ErrorCode;
 import com.team4ever.backend.global.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import com.team4ever.backend.domain.user.dto.UserCouponListResponse;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/user")
 @RequiredArgsConstructor
+@Tag(name = "사용자 API", description = "사용자 정보 및 개인 데이터 관리 API (인증 필요)")
+@SecurityRequirement(name = "cookieAuth")
 public class UserController {
 
     private final UserService svc;
 
-    // 신규 회원 생성
+    @Operation(summary = "신규 회원 생성")
     @PostMapping
     public ResponseEntity<Long> createUser(
             @Valid @RequestBody CreateUserRequest req
@@ -32,55 +38,61 @@ public class UserController {
         return ResponseEntity.ok(id);
     }
 
-    // user jwt로 회원 정보 조회
+    @Operation(summary = "현재 사용자 정보 조회")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @ApiResponse(responseCode = "401", description = "인증 실패")
     @GetMapping
     public ResponseEntity<UserResponse> getCurrentUser() {
+        // UserService의 getCurrentUser()는 이미 JWT에서 사용자 정보를 추출함
         UserResponse dto = svc.getCurrentUser();
         return ResponseEntity.ok(dto);
     }
 
-    /**
-     * 내 구독 상품 목록 조회
-     */
+    @Operation(summary = "내 구독 상품 목록 조회")
     @GetMapping("/subscriptions")
-    public ResponseEntity<BaseResponse<UserSubscriptionListResponse>> getUserSubscriptions(
-            @AuthenticationPrincipal OAuth2User oAuth2User
-    ) {
-        if (oAuth2User == null || oAuth2User.getAttribute("id") == null) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED);
-        }
+    public ResponseEntity<BaseResponse<UserSubscriptionListResponse>> getUserSubscriptions() {
+        // JWT에서 사용자 ID 추출
+        String userId = getCurrentUserId();
 
-        String oauthUserId = oAuth2User.getAttribute("id").toString();
+        UserSubscriptionListResponse response = svc.getUserSubscriptions(userId);
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
 
-        UserSubscriptionListResponse response = svc.getUserSubscriptions(oauthUserId); // userService → svc로 변경!
+    @Operation(summary = "좋아요한 쿠폰 목록 조회")
+    @GetMapping("/likes/coupons")
+    public ResponseEntity<BaseResponse<LikedCouponsResponse>> getLikedCoupons() {
+        // JWT에서 사용자 ID 추출
+        String userId = getCurrentUserId();
+
+        LikedCouponsResponse response = svc.getLikedCoupons(userId);
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    @Operation(summary = "보유중인 쿠폰 조회")
+    @GetMapping("/coupons")
+    public ResponseEntity<BaseResponse<UserCouponListResponse>> getMyCoupons() {
+        // JWT에서 사용자 ID 추출
+        String userId = getCurrentUserId();
+
+        UserCouponListResponse response = svc.getMyCoupons(userId);
         return ResponseEntity.ok(BaseResponse.success(response));
     }
 
     /**
-     * 좋아요한 쿠폰 목록 조회
+     * SecurityContext에서 현재 사용자 ID 추출
+     * JWT 인터셉터에서 설정한 사용자 ID를 반환
      */
-    @GetMapping("/likes/coupons")
-    public ResponseEntity<BaseResponse<LikedCouponsResponse>> getLikedCoupons(
-            @AuthenticationPrincipal OAuth2User oAuth2User
-    ) {
-        if (oAuth2User == null || oAuth2User.getAttribute("id") == null) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED);
+    private String getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            log.error("인증되지 않은 사용자의 접근 시도");
+            throw new RuntimeException("인증되지 않은 사용자입니다.");
         }
 
-        String oauthUserId = oAuth2User.getAttribute("id").toString();
+        // JWT 인터셉터에서 설정한 사용자 ID 반환
+        String userId = (String) authentication.getPrincipal();
+        log.debug("현재 사용자 ID: {}", userId);
 
-        LikedCouponsResponse response = svc.getLikedCoupons(oauthUserId);
-        return ResponseEntity.ok(BaseResponse.success(response));
-    }
-    //보유중인 쿠폰 조회
-    @GetMapping("/coupons")
-    public ResponseEntity<BaseResponse<UserCouponListResponse>> getMyCoupons(@AuthenticationPrincipal OAuth2User oAuth2User) {
-        if (oAuth2User == null || oAuth2User.getAttribute("id") == null) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED);
-        }
-
-        String oauthUserId = oAuth2User.getAttribute("id").toString();
-        UserCouponListResponse response = svc.getMyCoupons(oauthUserId);
-        return ResponseEntity.ok(BaseResponse.success(response));
+        return userId;
     }
 }

--- a/src/main/java/com/team4ever/backend/domain/user/Controller/UserController.java
+++ b/src/main/java/com/team4ever/backend/domain/user/Controller/UserController.java
@@ -5,6 +5,7 @@ import com.team4ever.backend.domain.user.dto.CreateUserRequest;
 import com.team4ever.backend.domain.user.dto.LikedCouponsResponse;
 import com.team4ever.backend.domain.user.dto.UserResponse;
 import com.team4ever.backend.domain.user.dto.UserSubscriptionListResponse;
+import com.team4ever.backend.domain.user.repository.UserRepository;
 import com.team4ever.backend.global.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -28,6 +29,7 @@ import com.team4ever.backend.domain.user.dto.UserCouponListResponse;
 public class UserController {
 
     private final UserService svc;
+    private final UserRepository userRepository;
 
     @Operation(summary = "신규 회원 생성")
     @PostMapping

--- a/src/main/java/com/team4ever/backend/domain/user/dto/UserSubscriptionDto.java
+++ b/src/main/java/com/team4ever/backend/domain/user/dto/UserSubscriptionDto.java
@@ -9,7 +9,10 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 public class UserSubscriptionDto {
-	private Integer id;
+	private Integer id;  // user_subscription_combinations.id (PK)
+
+	@JsonProperty("subscription_combination_id")  // 해지할 때 사용할 값
+	private Integer subscriptionCombinationId;
 
 	@JsonProperty("main_title")
 	private String mainTitle;
@@ -21,4 +24,15 @@ public class UserSubscriptionDto {
 
 	@JsonProperty("created_at")
 	private LocalDateTime createdAt;
+
+	// @Query에서 사용할 생성자 추가
+	public UserSubscriptionDto(Integer id, Integer subscriptionCombinationId, String mainTitle,
+							   String brandTitle, Integer price, LocalDateTime createdAt) {
+		this.id = id;
+		this.subscriptionCombinationId = subscriptionCombinationId;
+		this.mainTitle = mainTitle;
+		this.brandTitle = brandTitle;
+		this.price = price;
+		this.createdAt = createdAt;
+	}
 }

--- a/src/main/java/com/team4ever/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/team4ever/backend/global/config/SwaggerConfig.java
@@ -19,7 +19,7 @@ public class SwaggerConfig {
 						.addSecuritySchemes("cookieAuth", new SecurityScheme()
 								.type(SecurityScheme.Type.APIKEY)
 								.in(SecurityScheme.In.COOKIE)
-								.name("JSESSIONID")  // Spring 세션 쿠키 이름
+								.name("ACCESS_TOKEN")  // Spring 세션 쿠키 이름
 						)
 				)
 				.addSecurityItem(new SecurityRequirement().addList("cookieAuth"))

--- a/src/main/java/com/team4ever/backend/global/config/WebMvcConfig.java
+++ b/src/main/java/com/team4ever/backend/global/config/WebMvcConfig.java
@@ -1,6 +1,6 @@
 package com.team4ever.backend.global.config;
 
-import com.team4ever.backend.global.security.JwtInterceptor; // [추가]
+import com.team4ever.backend.global.security.JwtInterceptor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.HttpMessageConverter;
@@ -17,10 +17,10 @@ import java.util.List;
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {
 
-    private final JwtInterceptor jwtInterceptor;            // [추가]
+    private final JwtInterceptor jwtInterceptor;
 
-    public WebMvcConfig(JwtInterceptor jwtInterceptor) {    // [추가]
-        this.jwtInterceptor = jwtInterceptor;               // [추가]
+    public WebMvcConfig(JwtInterceptor jwtInterceptor) {
+        this.jwtInterceptor = jwtInterceptor;
     }
 
     @Bean
@@ -30,6 +30,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
         filter.setForceEncoding(true);
         return filter;
     }
+
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/images/**")
@@ -45,26 +46,44 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(jwtInterceptor)
+                // 보호할 경로 명시적으로 지정
+                .addPathPatterns("/api/**")
                 .excludePathPatterns(
-                        //REST API
+                        // === 인증 관련 (공개 API) ===
                         "/api/auth/**",
                         "/api/refresh",
-                        "/api/plans",
-                        "/api/plans/**",
+
+                        // === 공개 조회 API (인증 불필요) ===
+                        // 요금제 공개 조회
+                        "/api/plans",           // 전체 요금제 조회
+                        "/api/plans/*",         // 요금제 상세 조회 (GET /api/plans/{id})
+
+                        // 구독 관련 공개 조회
                         "/api/subscriptions/main",
                         "/api/subscriptions/brands",
+
+                        // 팝업 관련 공개 조회
                         "/api/popups",
-                        "/api/popups/**",
-                        "/api/coupons",
+                        "/api/popups/*",
+
+                        // 쿠폰 공개 조회만 허용
+                        "/api/coupons",         // GET /api/coupons 만 허용
+
+                        // 일반 채팅
                         "/api/chat",
-                        "/api/coupons/**",
-                        "/api/user/coupons",
-                        //Swagger
+
+                        // === Swagger 관련 ===
                         "/swagger-ui/**",
                         "/swagger-ui.html",
                         "/v3/api-docs/**",
                         "/swagger-resources/**",
-                        "/webjars/**"
+                        "/webjars/**",
+
+                        // === 정적 리소스 ===
+                        "/images/**",
+                        "/static/**",
+                        "/favicon.ico",
+                        "/error"
                 );
     }
 


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #110 

### 🔎 작업 내용
- [x] **Swagger Authorization 쿠키 인증 세션 이름 변경**
  - `JSESSIONID` → `ACCESS_TOKEN`으로 변경 완료

- [x] **컨트롤러 인증방식 변경**
  - `@AuthenticationPrincipal OAuth2User` → JWT 기반 `getCurrentUserId()` 방식으로 변경
  - 변경 완료된 컨트롤러 - 설명도 좀 덧붙여서 써뒀어욤
    - UserController
    - UserPlanController  
    - AttendanceController
    - CouponController
    - SubscriptionController
    - UBTIController (인증 필요로 변경)
    - ChatController

- [x] **구독 API 조합 아이디 추가**
  - `UserSubscriptionDto`에 `subscriptionCombinationId` 필드 추가
  - Repository 쿼리 수정하여 올바른 해지 ID 반환
  - 해지 API 안되던 부분 고침

### 📸 스크린샷
![image](https://github.com/user-attachments/assets/4eecff88-c0df-4dac-b618-8fc6df39395d)

### :loudspeaker: 전달사항

## `.env` 파일 수정 필요합니다!!!
> 엑세스 토큰 만료 시간 늘려서 수정해주세용

```
APP_AUTH_ACCESS_TOKEN_EXPIRATION_MSEC=720000
```

- 추가한 라이브러리나 특이 사항

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
