### PR TITLE
Feat: [EVER-198] Nearby Brands Store api complete

### DIFF
--- a/src/main/java/com/team4ever/backend/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/team4ever/backend/domain/coupon/controller/CouponController.java
@@ -30,6 +30,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.ArrayList;
 
 @Slf4j
 @RestController
@@ -330,32 +331,31 @@ public class CouponController {
     public BaseResponse<PlaceSearchResponse> getNearbyCoupons(
             @RequestParam Double lat,
             @RequestParam Double lng,
-            @RequestParam Integer brand_id) throws JSONException {
+            @RequestParam List<Integer> brand_id) throws JSONException {
 
-        // 1. brand_id로 브랜드명 조회 (예: BrandRepository 활용)
-        Brand brand = brandRepository.findBrandId(brand_id);
-        String brandName = brand.getName();
-        if (brandName == null || brandName.isBlank()) {
-            throw new IllegalArgumentException("브랜드를 찾을 수 없습니다.");
+        // brand_id 리스트 순회하며 브랜드명 조회 및 요청 처리
+        List<String> brandNames = new ArrayList<>();
+        for (Integer id : brand_id) {
+            Brand brand = brandRepository.findBrandId(id);
+            String name = brand.getName();
+            if (name == null || name.isBlank()) {
+                throw new IllegalArgumentException("브랜드를 찾을 수 없습니다. id=" + id);
+            }
+            brandNames.add(name);
         }
 
-        // 2. GooglePlaceService용 Request 생성
+        // PlaceSearchRequest에 brandNames 리스트 세팅
         PlaceSearchRequest req = new PlaceSearchRequest();
-        req.setTextQuery(brandName);
+        req.setTextQueryList(brandNames);
         req.setLatitude(lat);
         req.setLongitude(lng);
-        req.setRadius(500.0); // 500m 반경 등
-        req.setPageSize(10); // 결과 개수 제한
-        req.setOpenNow(false); // 영업중만 필터는 필요에 따라
+        req.setRadius(500.0);
+        req.setPageSize(10);
 
-        // 3. Service 호출
         PlaceSearchResponse result = placeService.search(req);
 
         return BaseResponse.success(result);
     }
-
-
-
 }
 
 

--- a/src/main/java/com/team4ever/backend/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/team4ever/backend/domain/coupon/controller/CouponController.java
@@ -326,7 +326,55 @@ public class CouponController {
         }
     }
 
-    @Operation(summary = "근처 쿠폰 사용 가능 매장 조회")
+    @Operation(
+            summary = "근처 쿠폰 사용 가능 매장 조회",
+            description = """
+        입력한 위도, 경도 주변 반경 500m 내에서
+        지정한 브랜드 ID 리스트에 해당하는 쿠폰 사용 가능 매장을 조회합니다.
+
+        - brand_id는 여러 개 전달 가능 (예: brand_id=1&brand_id=2)
+        - 각 brand_id에 해당하는 브랜드명으로 매장 검색 수행
+        - 각 브랜드마다 최대 10개까지만 반환 가능
+        """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "근처 쿠폰 매장 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                {
+                  "success": true,
+                  "message": "근처 쿠폰 매장 조회 성공",
+                  "data": {
+                    "places": [
+                      {
+                        "name": "배스킨라빈스 선릉역점",
+                        "lat": 37.5053571,
+                        "lng": 127.0472785,
+                        "address": "대한민국 서울특별시 강남구 역삼동 696-5"
+                      },
+                      {
+                        "name": "올리브영 강남점",
+                        "lat": 37.498,
+                        "lng": 127.027,
+                        "address": "대한민국 서울특별시 강남구 신사동 ..."
+                      }
+                    ]
+                  }
+                }
+                """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "유효하지 않은 brand_id 또는 요청 파라미터 오류",
+                    content = @Content(mediaType = "application/json")
+            )
+    })
     @GetMapping("/nearby")
     public BaseResponse<PlaceSearchResponse> getNearbyCoupons(
             @RequestParam Double lat,

--- a/src/main/java/com/team4ever/backend/domain/maps/dto/PlaceSearchRequest.java
+++ b/src/main/java/com/team4ever/backend/domain/maps/dto/PlaceSearchRequest.java
@@ -2,11 +2,11 @@ package com.team4ever.backend.domain.maps.dto;
 
 import lombok.Getter;
 import lombok.Setter;
+import java.util.List;
 
 @Getter @Setter
 public class PlaceSearchRequest {
-    private String textQuery;   // ex) "베스킨라빈스"
-    private Boolean openNow;    // 영업 중만
+    private List<String> textQueryList;  // ex) ["베스킨라빈스", "올리브영", "스타벅스"]
     private Integer pageSize;   // ex) 10
     private Double latitude;    // 중심 좌표 (UI에서 받음)
     private Double longitude;   // 중심 좌표 (UI에서 받음)

--- a/src/main/java/com/team4ever/backend/domain/maps/dto/PlaceSearchResponse.java
+++ b/src/main/java/com/team4ever/backend/domain/maps/dto/PlaceSearchResponse.java
@@ -14,6 +14,5 @@ public class PlaceSearchResponse {
         private Double lat;
         private Double lng;
         private String address;
-        private Boolean openNow;
     }
 }

--- a/src/main/java/com/team4ever/backend/domain/maps/dto/PlaceSearchResponse.java
+++ b/src/main/java/com/team4ever/backend/domain/maps/dto/PlaceSearchResponse.java
@@ -10,6 +10,7 @@ public class PlaceSearchResponse {
 
     @Getter @Setter
     public static class PlaceItem {
+        private int id;
         private String name;
         private Double lat;
         private Double lng;

--- a/src/main/java/com/team4ever/backend/domain/maps/repository/PlaceRepository.java
+++ b/src/main/java/com/team4ever/backend/domain/maps/repository/PlaceRepository.java
@@ -23,55 +23,76 @@ public class PlaceRepository {
     private String apiKey;
 
     public PlaceSearchResponse searchPlaces(PlaceSearchRequest req) throws JSONException {
-        String url = "https://places.googleapis.com/v1/places:searchText";
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.set("X-Goog-Api-Key", apiKey);
-        headers.set("X-Goog-FieldMask", "places.displayName,places.location,places.formattedAddress");
+        List<PlaceSearchResponse.PlaceItem> allItems = new ArrayList<>();
 
-        JSONObject circle = new JSONObject();
-        circle.put("center", new JSONObject()
-                .put("latitude", req.getLatitude())
-                .put("longitude", req.getLongitude()));
-        circle.put("radius", req.getRadius());
+        for (String brand : req.getTextQueryList()){
+            String url = "https://places.googleapis.com/v1/places:searchText";
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.set("X-Goog-Api-Key", apiKey);
+            headers.set("X-Goog-FieldMask", "places.displayName,places.location,places.formattedAddress");
 
-        JSONObject locationBias = new JSONObject();
-        locationBias.put("circle", circle);
+            JSONObject circle = new JSONObject();
+            circle.put("center", new JSONObject()
+                    .put("latitude", req.getLatitude())
+                    .put("longitude", req.getLongitude()));
+            circle.put("radius", req.getRadius());
 
-        JSONObject body = new JSONObject();
-        body.put("textQuery", req.getTextQuery());
-        if (req.getOpenNow() != null) body.put("openNow", req.getOpenNow());
-        if (req.getPageSize() != null) body.put("pageSize", req.getPageSize());
-        body.put("locationBias", locationBias);
-        body.put("languageCode", "ko");
+            JSONObject locationBias = new JSONObject();
+            locationBias.put("circle", circle);
 
-        HttpEntity<String> entity = new HttpEntity<>(body.toString(), headers);
-        ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.POST, entity, String.class);
+            JSONObject body = new JSONObject();
+            body.put("textQuery", brand);
+            body.put("openNow", true);
+            if (req.getPageSize() != null) body.put("pageSize", req.getPageSize());
+            body.put("locationBias", locationBias);
+            body.put("languageCode", "ko");
 
-        JSONObject responseJson = new JSONObject(response.getBody());
-        JSONArray placesArray = responseJson.optJSONArray("places");
+            HttpEntity<String> entity = new HttpEntity<>(body.toString(), headers);
+            ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.POST, entity, String.class);
 
-        List<PlaceSearchResponse.PlaceItem> items = new ArrayList<>();
-        if (placesArray != null) {
-            for (int i = 0; i < placesArray.length(); i++) {
-                JSONObject obj = placesArray.getJSONObject(i);
-                PlaceSearchResponse.PlaceItem item = new PlaceSearchResponse.PlaceItem();
+            JSONObject responseJson = new JSONObject(response.getBody());
+            JSONArray placesArray = responseJson.optJSONArray("places");
 
-                item.setName(obj.optJSONObject("displayName") != null ?
-                        obj.getJSONObject("displayName").optString("text", "") : "");
-                item.setLat(obj.optJSONObject("location") != null ?
-                        obj.getJSONObject("location").optDouble("latitude", 0.0) : null);
-                item.setLng(obj.optJSONObject("location") != null ?
-                        obj.getJSONObject("location").optDouble("longitude", 0.0) : null);
-                item.setAddress(obj.optString("formattedAddress", ""));
-                item.setOpenNow(obj.optJSONObject("openingHours") != null ?
-                        obj.getJSONObject("openingHours").optBoolean("openNow", false) : null);
+            if (placesArray != null) {
+                for (int i = 0; i < placesArray.length(); i++) {
+                    JSONObject obj = placesArray.getJSONObject(i);
 
-                items.add(item);
+                    JSONObject displayNameObj = obj.optJSONObject("displayName");
+                    if (displayNameObj == null) continue;
+
+                    // languageCode가 "ko"인지 확인
+                    String langCode = displayNameObj.optString("languageCode", "");
+                    if (!"ko".equals(langCode)) {
+                        // 한글 응답이 아니면 건너뜀
+                        continue;
+                    }
+
+                    String placeName = displayNameObj.optString("text", "");
+
+                    // 브랜드명 포함 여부 체크 (예: brand 변수에 브랜드명 저장되어 있다고 가정)
+                    // brand 변수는 해당 API 호출 시 사용한 브랜드명이어야 합니다.
+                    if (!placeName.toLowerCase().contains(brand.toLowerCase())) {
+                        continue;  // 브랜드명이 포함되지 않으면 건너뜀
+                    }
+
+                    PlaceSearchResponse.PlaceItem item = new PlaceSearchResponse.PlaceItem();
+                    item.setName(placeName);
+
+                    JSONObject locationObj = obj.optJSONObject("location");
+                    if (locationObj != null) {
+                        item.setLat(locationObj.optDouble("latitude", 0.0));
+                        item.setLng(locationObj.optDouble("longitude", 0.0));
+                    }
+
+                    item.setAddress(obj.optString("formattedAddress", ""));
+                    allItems.add(item);
+                }
             }
         }
+
         PlaceSearchResponse result = new PlaceSearchResponse();
-        result.setPlaces(items);
+        result.setPlaces(allItems);
         return result;
     }
 }

--- a/src/main/java/com/team4ever/backend/domain/maps/repository/PlaceRepository.java
+++ b/src/main/java/com/team4ever/backend/domain/maps/repository/PlaceRepository.java
@@ -24,6 +24,7 @@ public class PlaceRepository {
 
     public PlaceSearchResponse searchPlaces(PlaceSearchRequest req) throws JSONException {
         List<PlaceSearchResponse.PlaceItem> allItems = new ArrayList<>();
+        int idCounter = 1;
 
         for (String brand : req.getTextQueryList()){
             String url = "https://places.googleapis.com/v1/places:searchText";
@@ -77,6 +78,8 @@ public class PlaceRepository {
                     }
 
                     PlaceSearchResponse.PlaceItem item = new PlaceSearchResponse.PlaceItem();
+                    item.setId(idCounter);
+                    idCounter++;
                     item.setName(placeName);
 
                     JSONObject locationObj = obj.optJSONObject("location");

--- a/src/main/java/com/team4ever/backend/global/security/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/team4ever/backend/global/security/CustomOAuth2SuccessHandler.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 
 @Component
 public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler {
-    private static final String FRONTEND_URL = "http://localhost:5173/authcallback";
+    private static final String FRONTEND_URL = "http://localhost:5173";
 
     private final JwtTokenProvider jwtProvider;
     private final RedisService redisService;
@@ -90,6 +90,6 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
 
         response.addHeader("Set-Cookie", cookie.toString());
 
-        response.sendRedirect(FRONTEND_URL + "/");
+        response.sendRedirect(FRONTEND_URL + "/authcallback");
     }
 }


### PR DESCRIPTION
### #️⃣연관된 이슈

> close: #120 

### 🔎 작업 내용

- [x] 기존 brand_id 하나에서, request body에 brand_id 배열을 넣으면 배열 안에 해당하는 모든 매장 한 번에 반환 가능토록 변경
- [x] 열린 매장만 조회 가능, 과정에서 한국어로 위치 정보 조회 안 하는 데이터는 배제
- [x] 추가로, google 탐색 api로 가끔 관련 없는 매장이 탐색되는 경우 있는데 이 경우의 데이터도 배제

### 📸 스크린샷

### :loudspeaker: 전달사항

- 추가한 라이브러리나 특이 사항

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
