### PR TITLE
Feat: [EVER-203] 사용량 기반 요금제 추천 API 연동

### DIFF
--- a/src/main/java/com/team4ever/backend/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/team4ever/backend/domain/chat/controller/ChatController.java
@@ -1,19 +1,27 @@
 package com.team4ever.backend.domain.chat.controller;
 
 import com.team4ever.backend.domain.chat.dto.ChatRequest;
+import com.team4ever.backend.domain.chat.dto.UsageRecommendRequest;
 import com.team4ever.backend.domain.chat.service.ChatService;
+import com.team4ever.backend.domain.user.Entity.User;
+import com.team4ever.backend.domain.user.repository.UserRepository;
+import com.team4ever.backend.global.exception.CustomException;
+import com.team4ever.backend.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 
@@ -27,6 +35,7 @@ import java.util.Set;
 public class ChatController {
 
 	private final ChatService chatService;
+	private final UserRepository userRepository;
 
 	// 유효한 톤 목록을 상수로 관리
 	private static final Set<String> VALID_TONES = Set.of("general", "muneoz");
@@ -121,6 +130,143 @@ public class ChatController {
 				request.getSession_id(), validatedTone);
 
 		return chatService.streamChatLikes(request);
+	}
+
+	@Operation(
+			summary = "사용량 기반 요금제 추천",
+			description = "사용자의 실제 데이터/음성/SMS 사용 패턴을 AI로 분석하여 최적의 요금제를 추천합니다.\n\n" +
+					"**특징:**\n" +
+					"- 6가지 사용자 타입 분석 (헤비/안정추구/균형/스마트/절약/라이트)\n" +
+					"- 구체적 절약/추가 비용 계산 (월/연간)\n" +
+					"- 실생활 비교 설명 (치킨값, 넷플릭스 등)\n" +
+					"- 가중평균 사용률 계산 (데이터 60% + 음성 30% + SMS 10%)\n\n" +
+					"**tone 파라미터:**\n" +
+					"- `general`: 정중하고 전문적인 상담원 톤\n" +
+					"- `muneoz`: 친근하고 활발한 무너즈 캐릭터 톤\n\n" +
+					"**응답 형식:**\n" +
+					"1. usage_analysis - 사용량 분석 데이터\n" +
+					"2. plan_recommendations - 추천 요금제 카드\n" +
+					"3. message_start - 스트리밍 시작\n" +
+					"4. message_chunk - 맞춤 설명 (스트리밍)\n" +
+					"5. message_end - 스트리밍 완료"
+	)
+	@ApiResponses(value = {
+			@ApiResponse(
+					responseCode = "200",
+					description = "사용량 기반 추천 응답 스트림 성공",
+					content = @Content(mediaType = "text/event-stream")
+			),
+			@ApiResponse(
+					responseCode = "400",
+					description = "잘못된 요청"
+			),
+			@ApiResponse(
+					responseCode = "401",
+					description = "인증 실패 (JWT 토큰 필요)"
+			),
+			@ApiResponse(
+					responseCode = "404",
+					description = "사용자 정보 없음"
+			),
+			@ApiResponse(
+					responseCode = "500",
+					description = "서버 내부 오류"
+			)
+	})
+	@SecurityRequirement(name = "cookieAuth")
+	@PostMapping(
+			value = "/usage",
+			consumes = MediaType.APPLICATION_JSON_VALUE,
+			produces = MediaType.TEXT_EVENT_STREAM_VALUE
+	)
+	public Flux<ServerSentEvent<String>> usageRecommend(
+			@Parameter(
+					description = "사용량 기반 추천 요청 정보",
+					required = true,
+					content = @Content(schema = @Schema(implementation = UsageRecommendRequest.class))
+			)
+			@Valid @RequestBody UsageRecommendRequest request
+	) {
+		// tone 검증 및 정규화
+		String validatedTone = validateAndNormalizeTone(request.getTone());
+		request.setTone(validatedTone);
+
+		// JWT에서 사용자 ID 추출
+		int userId = getCurrentUserIdAsInt();
+
+		log.info("사용량 기반 추천 요청 - user_id: {}, tone: {}", userId, validatedTone);
+
+		return chatService.streamUsageRecommend(userId, request);
+	}
+
+	/**
+	 * JWT SecurityContext에서 현재 사용자 ID 추출
+	 * @return JWT에서 추출한 사용자 ID (String)
+	 * @throws CustomException 인증 정보가 없는 경우
+	 */
+	private String getCurrentUserId() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		if (authentication == null || !authentication.isAuthenticated()) {
+			log.error("인증되지 않은 사용자의 사용량 추천 API 접근 시도");
+			throw new CustomException(ErrorCode.UNAUTHORIZED);
+		}
+
+		String userId = (String) authentication.getPrincipal();
+		log.debug("JWT에서 추출한 사용자 ID: {}", userId);
+		return userId;
+	}
+
+	/**
+	 * JWT에서 추출한 User.userId(String)로 User 엔티티를 조회하여 PK(Long) 반환
+	 * @return User 엔티티의 PK (Long)
+	 * @throws CustomException 사용자를 찾을 수 없는 경우
+	 */
+	private Long getCurrentUserPk() {
+		try {
+			String userIdStr = getCurrentUserId();
+
+			// User.userId(String)로 User 엔티티 조회
+			User user = userRepository.findByUserId(userIdStr)
+					.orElseThrow(() -> {
+						log.error("사용자를 찾을 수 없음: {}", userIdStr);
+						return new CustomException(ErrorCode.USER_NOT_FOUND);
+					});
+
+			Long userPkId = user.getId();
+			log.debug("JWT userId: {} -> User PK: {}", userIdStr, userPkId);
+
+			return userPkId;
+
+		} catch (CustomException e) {
+			throw e; // CustomException은 그대로 재던지기
+		} catch (Exception e) {
+			log.error("사용자 ID 변환 중 예상치 못한 오류 발생: {}", e.getMessage());
+			throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	/**
+	 * FastAPI에서 요구하는 int 타입 사용자 ID 반환
+	 * @return 사용자 PK를 int로 변환
+	 * @throws CustomException 변환 실패 시
+	 */
+	private int getCurrentUserIdAsInt() {
+		try {
+			Long userPk = getCurrentUserPk();
+
+			// Long에서 int로 안전하게 변환
+			if (userPk > Integer.MAX_VALUE) {
+				log.error("사용자 PK가 int 범위를 초과: {}", userPk);
+				throw new CustomException(ErrorCode.INVALID_USER_ID);
+			}
+
+			return userPk.intValue();
+		} catch (CustomException e) {
+			throw e;
+		} catch (Exception e) {
+			log.error("사용자 ID int 변환 중 오류: {}", e.getMessage());
+			throw new CustomException(ErrorCode.INVALID_USER_ID);
+		}
 	}
 
 	/**

--- a/src/main/java/com/team4ever/backend/domain/chat/dto/UsageRecommendRequest.java
+++ b/src/main/java/com/team4ever/backend/domain/chat/dto/UsageRecommendRequest.java
@@ -1,0 +1,27 @@
+package com.team4ever.backend.domain.chat.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import jakarta.validation.constraints.Pattern;
+
+@Getter
+@Setter
+public class UsageRecommendRequest {
+
+	@Pattern(regexp = "^(general|muneoz)$", message = "톤은 'general' 또는 'muneoz'만 가능합니다.")
+	private String tone = "general";  // 기본값: general
+
+	// user_id는 JWT SecurityContext에서 자동 추출되므로 필드 필요 없음
+
+	public void setTone(String tone) {
+		if (tone == null || tone.trim().isEmpty()) {
+			this.tone = "general";
+		} else if ("general".equals(tone) || "muneoz".equals(tone)) {
+			this.tone = tone;
+		} else {
+			this.tone = "general";
+		}
+	}
+}

--- a/src/main/java/com/team4ever/backend/domain/chat/dto/UsageRecommendResponse.java
+++ b/src/main/java/com/team4ever/backend/domain/chat/dto/UsageRecommendResponse.java
@@ -1,0 +1,69 @@
+package com.team4ever.backend.domain.chat.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class UsageRecommendResponse {
+	private String type;
+	private Object data;
+
+	// 사용량 분석 데이터 전용 내부 클래스
+	@Data
+	public static class UsageAnalysisData {
+		@JsonProperty("user_id")
+		private int userId;
+
+		@JsonProperty("current_plan")
+		private String currentPlan;
+
+		@JsonProperty("current_price")
+		private int currentPrice;
+
+		@JsonProperty("remaining_data")
+		private int remainingData;
+
+		@JsonProperty("remaining_voice")
+		private int remainingVoice;
+
+		@JsonProperty("remaining_sms")
+		private int remainingSms;
+
+		@JsonProperty("usage_percentage")
+		private double usagePercentage;
+	}
+
+	// 요금제 추천 데이터 전용 내부 클래스
+	@Data
+	public static class PlanRecommendationsData {
+		private List<PlanInfo> plans;
+	}
+
+	// 추천 요금제 정보
+	@Data
+	public static class PlanInfo {
+		private int id;
+		private String name;
+		private int price;
+		private String data;
+		private String voice;
+		private String speed;
+
+		@JsonProperty("share_data")
+		private String shareData;
+
+		private String sms;
+		private String description;
+	}
+
+	// 메시지 청크 데이터 (스트리밍)
+	@Data
+	public static class MessageChunkData {
+		private String content;
+	}
+}

--- a/src/main/java/com/team4ever/backend/domain/chat/service/ChatService.java
+++ b/src/main/java/com/team4ever/backend/domain/chat/service/ChatService.java
@@ -1,6 +1,7 @@
 package com.team4ever.backend.domain.chat.service;
 
 import com.team4ever.backend.domain.chat.dto.ChatRequest;
+import com.team4ever.backend.domain.chat.dto.UsageRecommendRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
@@ -16,19 +17,22 @@ public class ChatService {
 	private final WebClient webClient;
 	private final String chatPath;
 	private final String chatLikesPath;
+	private final String usagePath;
 
 	public ChatService(
 			WebClient.Builder webClientBuilder,
 			@Value("${fastapi.chat.host}") String host,
 			@Value("${fastapi.chat.port}") int port,
 			@Value("${fastapi.chat.path.chat}") String chatPath,
-			@Value("${fastapi.chat.path.likes}") String chatLikesPath
+			@Value("${fastapi.chat.path.likes}") String chatLikesPath,
+			@Value("${fastapi.chat.path.usage}") String usagePath
 	) {
 		this.webClient = webClientBuilder
 				.baseUrl(String.format("http://%s:%d", host, port))
 				.build();
 		this.chatPath = chatPath;
 		this.chatLikesPath = chatLikesPath;
+		this.usagePath = usagePath;
 	}
 
 	/**
@@ -63,5 +67,25 @@ public class ChatService {
 				.bodyToFlux(String.class)
 				.map(data -> ServerSentEvent.builder(data).build())
 				.doOnError(error -> log.error("좋아요 추천 스트리밍 오류: ", error));
+	}
+
+	/**
+	 * 사용량 기반 추천 스트리밍
+	 */
+	public Flux<ServerSentEvent<String>> streamUsageRecommend(int userId, UsageRecommendRequest request) {
+		log.info("FastAPI 사용량 추천 호출 - user_id: {}, tone: {}", userId, request.getTone());
+
+		return webClient.post()
+				.uri(uriBuilder -> uriBuilder
+						.path(usagePath + "/recommend")
+						.queryParam("user_id", userId)
+						.queryParam("tone", request.getTone())
+						.build())
+				.accept(MediaType.TEXT_EVENT_STREAM)
+				.retrieve()
+				.bodyToFlux(String.class)
+				.map(data -> ServerSentEvent.builder(data).build())
+				.doOnError(error -> log.error("사용량 추천 스트리밍 오류: ", error))
+				.doOnComplete(() -> log.info("사용량 추천 스트리밍 완료 - user_id: {}", userId));
 	}
 }

--- a/src/main/java/com/team4ever/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/team4ever/backend/global/exception/ErrorCode.java
@@ -35,6 +35,15 @@ public enum ErrorCode {
 	COUPON_NOT_CLAIMED(HttpStatus.NOT_FOUND, "발급된 쿠폰이 없습니다."),
 	COUPON_ALREADY_USED(HttpStatus.CONFLICT, "이미 사용된 쿠폰입니다."),
 
+	// 채팅 및 추천 관련 에러
+	CHAT_AI_API_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "AI 채팅 서비스 연결 오류가 발생했습니다."),
+	USAGE_RECOMMENDATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "사용량 기반 추천 생성 중 오류가 발생했습니다."),
+	LIKES_RECOMMENDATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "좋아요 기반 추천 생성 중 오류가 발생했습니다."),
+	CHAT_STREAMING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "채팅 스트리밍 중 오류가 발생했습니다."),
+	INVALID_TONE_REQUEST(HttpStatus.BAD_REQUEST, "유효하지 않은 톤 요청입니다."),
+	FASTAPI_CONNECTION_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "FastAPI 서버 연결 오류가 발생했습니다."),
+	USER_USAGE_DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자의 사용량 데이터를 찾을 수 없습니다."),
+
 	// UBTI 관련 에러
 	UBTI_DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "UBTI 타입 데이터를 찾을 수 없습니다."),
 	UBTI_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "UBTI 결과 생성 중 오류가 발생했습니다."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -117,6 +117,7 @@ fastapi:
     path:
       chat: /api/chat
       likes: /api/chat/likes
+      usage: /api/chat/usage
   ubti:
     host: ${FASTAPI_HOST:localhost}
     port: ${FASTAPI_PORT:8000}


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #125 

### 🔎 작업 내용
> Swagger 문서에 상세히 작성해뒀으니 참고하시면 됩니다.
- [x] 사용량 기반 추천 API 엔드포인트 구현 - **POST** `api/chat/usage`
- [x] 시큐리티 컨텍스트 : 인증된 사용자 기반 

### 📸 스크린샷
> 사용량 관련 타입 6가지 응답 분류 기준
<img width="573" alt="스크린샷 2025-06-20 오전 12 56 15" src="https://github.com/user-attachments/assets/d08fa9ca-0450-4d83-9f3a-523841e6b5a1" />

> 예시 응답 
<img width="670" alt="image" src="https://github.com/user-attachments/assets/78831e7e-fe87-4414-8ead-2a6a1abbec06" />

```
1. usage_analysis     - 사용량 분석 데이터 json data 
2. plan_recommendations - 추천 요금제 카드용 json data 
3. message_start      - 스트리밍 시작
4. message_chunk      - 스트리밍 청크 data
5. message_end        - 스트리밍 완료
```

### :loudspeaker: 전달사항
> 프론트에서 위 응답 구조대로 파싱해서 챗봇에서 렌더링해야 합니다!
- 추가한 라이브러리나 특이 사항

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
