### PR TITLE
Refactor: [EVER-226] 백엔드 응답에 mission type 포함되도록 UserMissionDto 수정

### DIFF
--- a/src/main/java/com/team4ever/backend/domain/mission/dto/UserMissionDto.java
+++ b/src/main/java/com/team4ever/backend/domain/mission/dto/UserMissionDto.java
@@ -2,6 +2,7 @@ package com.team4ever.backend.domain.mission.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.team4ever.backend.domain.mission.entity.MissionStatus;
+import com.team4ever.backend.domain.mission.entity.MissionType;
 import com.team4ever.backend.domain.mission.entity.UserMission;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -39,6 +40,9 @@ public class UserMissionDto {
     @JsonProperty("is_completed")
     private boolean isCompleted;
 
+    @JsonProperty("type")
+    private MissionType type;
+
     public static UserMissionDto from(UserMission entity) {
         return new UserMissionDto(
                 entity.getId(),
@@ -50,7 +54,8 @@ public class UserMissionDto {
                 entity.getStatus(),
                 entity.getMission().getRewardPoint(),
                 entity.getCreatedAt(),
-                entity.isCompleted()
+                entity.isCompleted(),
+                entity.getMission().getType()
         );
     }
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #135

---

### 🔎 작업 내용

- [x] `UserMissionDto` 클래스에 `type: MissionType` 필드 추가
- [x] 응답 예시에 `type` 필드가 포함되는지 Swagger로 확인
- [x] 프론트에서 `mission.type` 값이 정상적으로 들어오는지 콘솔 확인
- [x] 출석 미션에 한해 `user.attendanceStreak`를 기반으로 진행도/상태를 직접 갱신

---

### 📸 스크린샷

#### ✅ 이제 응답에 `mission.type`도 포함됩니다  
![mission-type 응답](https://github.com/user-attachments/assets/08673b15-dac6-4a03-9a86-0b68b9b9a658)

#### ✅ 프론트 로그 확인  
![프론트 콘솔](https://github.com/user-attachments/assets/4bd06865-faa4-441a-be3d-58b86cbc214b)

#### ✅ 프론트 화면 적용 결과

| 출석 달력                                     | 출석 미션 상태                                 |
|----------------------------------------------|----------------------------------------------|
| ![출석 달력](https://github.com/user-attachments/assets/d06d41c7-b3f7-429a-b19f-4b0856dd893f) | ![출석 미션](https://github.com/user-attachments/assets/f172b5c1-d6d1-47aa-9cb4-0304ab1a81b2) |

---

### :loudspeaker: 전달사항

#### ✅ 출석 미션 진행도에 `attendanceStreak`를 직접 사용하는 이유

기존에는 출석 미션의 진행도(`progressCount`)가 서버에서 별도로 관리되고 있었지만  
**연속 출석이 끊겨도 자동 초기화되지 않는 문제가 있었습니다.**

기존 mission API를 수정하기보다는,  
이미 관리되고 있는 **`user` 테이블의 `attendanceStreak` 필드를 활용**하는 것이 더 경제적이라고 판단했습니다.  
이에 따라 **프론트에서는 `UserProfile` 응답의 `attendanceStreak` 값을 기반으로**,  
출석 미션의 `current_progress`와 `status`를 직접 계산하도록 수정했습니다.


### 💡 이 방식의 장점

- ✅ **끊기면 자동 초기화됨**  
  → `attendanceStreak = 0` 이 되면 진행도도 자연스럽게 0으로 표시됨
- ✅ **실시간 UX 개선**  
  → 출석 후 바로 달력, 미션, 배너까지 일관되게 반영됨
- ✅ **서버 수정 없이 클라이언트에서 일관된 처리**  
  → 미션 목록, streak, 도장이 모두 동기화됨

---

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
