### PR TITLE
Feat: [EVER-233] 쿠폰에 startDate, endDate 추가 구현

### DIFF
--- a/src/main/java/com/team4ever/backend/domain/user/Service/UserServiceImpl.java
+++ b/src/main/java/com/team4ever/backend/domain/user/Service/UserServiceImpl.java
@@ -252,7 +252,9 @@ public class UserServiceImpl implements UserService {
                                     uc.getCoupon().getBrand().getName(),
                                     uc.getCoupon().getBrand().getImageUrl()
                             ),
-                            uc.getIsUsed()
+                            uc.getIsUsed(),
+                            uc.getCoupon().getStartDate().toString(),
+                            uc.getCoupon().getEndDate().toString()
                     ))
                     .collect(Collectors.toCollection(ArrayList::new));
 

--- a/src/main/java/com/team4ever/backend/domain/user/dto/CouponInfoResponse.java
+++ b/src/main/java/com/team4ever/backend/domain/user/dto/CouponInfoResponse.java
@@ -4,7 +4,9 @@ public record CouponInfoResponse(
     Long couponId,
     String title,
     BrandInfo brand,
-    boolean isUsed
+    boolean isUsed,
+    String startDate,
+    String endDate
 ) {
     public record BrandInfo(Long id, String name, String imageUrl) {}
 }

--- a/src/main/java/com/team4ever/backend/domain/user/dto/CouponInfoResponse.java
+++ b/src/main/java/com/team4ever/backend/domain/user/dto/CouponInfoResponse.java
@@ -1,12 +1,34 @@
 package com.team4ever.backend.domain.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record CouponInfoResponse(
-    Long couponId,
-    String title,
-    BrandInfo brand,
-    boolean isUsed,
-    String startDate,
-    String endDate
+        @JsonProperty("coupon_id")
+        Long couponId,
+
+        @JsonProperty("title")
+        String title,
+
+        @JsonProperty("brand")
+        BrandInfo brand,
+
+        @JsonProperty("is_used")
+        boolean isUsed,
+
+        @JsonProperty("start_date")
+        String startDate,
+
+        @JsonProperty("end_date")
+        String endDate
 ) {
-    public record BrandInfo(Long id, String name, String imageUrl) {}
+    public record BrandInfo(
+            @JsonProperty("id")
+            Long id,
+
+            @JsonProperty("name")
+            String name,
+
+            @JsonProperty("image_url")
+            String imageUrl
+    ) {}
 }


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #137 

### 🔎 작업 내용

- 프론트에서 쿠폰 유효기간을 표시하기 위한 필드 부족 문제 해결
- `/api/user/coupons` 응답 DTO (`CouponInfoResponse`)에 `startDate`, `endDate` 필드 추가
- `UserServiceImpl.getMyCoupons()` 내에서 `Coupon` 엔티티의 `startDate`, `endDate` 값을 응답에 포함되도록 수정

### 📸 스크린샷
- swagger 테스트
![Uploading image.png…]()


## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
