### PR TITLE
Refactor: [EVER-243] 백엔드 응답에 category 포함되도록 수정

### DIFF
--- a/src/main/java/com/team4ever/backend/domain/benefit/dto/BenefitPreviewResponse.java
+++ b/src/main/java/com/team4ever/backend/domain/benefit/dto/BenefitPreviewResponse.java
@@ -14,12 +14,14 @@ public class BenefitPreviewResponse {
     private LocalDate date;
     @JsonProperty("image_url")
     private String imageUrl;
+    private String category;
 
     public static BenefitPreviewResponse from(Benefit benefit) {
         return new BenefitPreviewResponse(
                 benefit.getBrand().getName(),
                 benefit.getBenefitDate(),
-                benefit.getBrand().getImageUrl()
+                benefit.getBrand().getImageUrl(),
+                benefit.getBrand().getCategory()
         );
     }
 }


### PR DESCRIPTION
…ponse 수정

### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #140

### 🔎 작업 내용

- [x] 기존 /api/uplus-benefits 엔드포인트 응답에 포함된 필드를 확장했습니다.
 - 변경 전: brand, date, imageUrl만 응답
 - 변경 후: brand, date, imageUrl, category 응답 포함

### 📸 스크린샷
이제 스웨거 응답에 category도 포함됩니다.
![image](https://github.com/user-attachments/assets/c95f0848-21f9-41aa-b306-83b13ef12dbb)


### :loudspeaker: 전달사항

- 프론트엔드에서 **유플투쁠 혜택 카테고리 기반 필터링 구현을 지원**하기 위해 백엔드 코드를 수정하였습니다.

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
