### PR TITLE
Feat: [EVER-241] 회원가입 시 연동 안될 경우 랜덤 부여

### DIFF
--- a/src/main/java/com/team4ever/backend/domain/user/Service/UserServiceImpl.java
+++ b/src/main/java/com/team4ever/backend/domain/user/Service/UserServiceImpl.java
@@ -1,6 +1,8 @@
 package com.team4ever.backend.domain.user.Service;
 
 import com.team4ever.backend.domain.mission.service.MissionService;
+import com.team4ever.backend.domain.plan.entity.Plan;
+import com.team4ever.backend.domain.plan.repository.PlanRepository;
 import com.team4ever.backend.domain.user.dto.CreateUserRequest;
 import com.team4ever.backend.domain.user.dto.UserResponse;
 import jakarta.servlet.http.Cookie;
@@ -36,6 +38,7 @@ public class UserServiceImpl implements UserService {
     private final JwtTokenProvider jwtProvider;
     private final HttpServletRequest request;
     private final MissionService missionService;
+    private final PlanRepository planRepository;
 
     public UserServiceImpl(UserRepository repo,
                            UserSubscriptionCombinationRepository userSubscriptionCombinationRepository,
@@ -43,7 +46,8 @@ public class UserServiceImpl implements UserService {
                            UserCouponRepository userCouponRepository,
                            MissionService missionService,
                            JwtTokenProvider jwtProvider,
-                           HttpServletRequest request) {
+                           HttpServletRequest request,
+                           PlanRepository planRepository) {
         this.repo = repo;
         this.userSubscriptionCombinationRepository = userSubscriptionCombinationRepository;
         this.couponLikeRepository = couponLikeRepository;
@@ -51,6 +55,7 @@ public class UserServiceImpl implements UserService {
         this.jwtProvider = jwtProvider;
         this.request = request;
         this.missionService = missionService;
+        this.planRepository = planRepository;
     }
 
     @Override
@@ -60,12 +65,20 @@ public class UserServiceImpl implements UserService {
             throw new IllegalArgumentException("이미 존재하는 userId 입니다.");
         }
 
-        Integer planId = req.getPlanId() != null
-                ? req.getPlanId()
-                : DEFAULT_PLAN_ID;
-
+        Integer planId = req.getPlanId();
+        if (planId == null) {
+            List<Plan> activePlans = planRepository.findByIsActiveTrue();
+            if (!activePlans.isEmpty()) {
+                Plan randomPlan = activePlans.get((int) (Math.random() * activePlans.size()));
+                planId = randomPlan.getId();
+                log.info("무작위 요금제 부여 - planId: {}", planId);
+            } else {
+                log.error("활성화된 요금제가 없습니다. 사용자 생성 불가");
+                throw new CustomException(ErrorCode.PLAN_NOT_FOUND);
+            }
+        }
         User u = User.builder()
-                .planId(req.getPlanId())
+                .planId(planId)
                 .userId(req.getUserId())
                 .email(req.getEmail())
                 .phoneNumber(req.getPhoneNumber())


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #139 

### 🔎 작업 내용

- UserServiceImpl.createUser() 내 요금제(planId) 지정 로직 수정
  CreateUserRequest에 planId가 없을 경우, PlanRepository.findByIsActiveTrue()를 통해 활성 요금제 목록을 조회하고, 무작위로 하나를 선택해 해당 planId로 자동 할당

- 관련 예외 처리 추가 (PLAN_NOT_FOUND)
- UserServiceImpl에 PlanRepository 의존성 추가

### 📸 스크린샷
- 실제 회원가입부터 테스트

![화면 녹화 중 2025-06-22 204153](https://github.com/user-attachments/assets/f7a99cd5-e88c-4f83-b771-8a090f0cd171)


### :loudspeaker: 전달사항


## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
