### PR TITLE
Fix: [EVER-277] ubti 결과 response에 라이프 브랜드 추가

### DIFF
--- a/src/main/java/com/team4ever/backend/domain/ubti/dto/UBTIResult.java
+++ b/src/main/java/com/team4ever/backend/domain/ubti/dto/UBTIResult.java
@@ -89,5 +89,29 @@ public class UBTIResult {
 			@JsonProperty("description")
 			private String description;
 		}
+
+		@JsonProperty("brand")
+		private Brand brand;
+
+		@Getter
+		@Setter
+		@ToString
+		@JsonIgnoreProperties(ignoreUnknown = true)
+		public static class Brand {
+			@JsonProperty("id")
+			private int id;
+
+			@JsonProperty("name")
+			private String name;
+
+			@JsonProperty("image_url")
+			private String image_url;
+
+			@JsonProperty("description")
+			private String description;
+
+			@JsonProperty("category")
+			private String category;
+		}
 	}
 }


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #148 

### 🔎 작업 내용

- [x] ubti 결과 response에 라이프 브랜드 추가
### 📸 스크린샷
![image](https://github.com/user-attachments/assets/dad8ada1-95e9-4729-a4c8-aaa3092ede1e)

### :loudspeaker: 전달사항

- 추가한 라이브러리나 특이 사항

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
